### PR TITLE
Resources.attribute_to_field/2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,12 @@
 
 ### Enhancements
 * [#1](https://github.com/C-S-D/calcinator/pull/1) - Expose `attribute_to_field` that was used in `Calcinator.Resources.Sort` as it is useful in other places instead of using `String.to_existing_atom`, which doesn't handle the hyphenation and can fail if the atom hasn't been loaded yet. - [@KronicDeth](https://github.com/KronicDeth)
+
+
+### Bug Fixes
+* [#1](https://github.com/C-S-D/calcinator/pull/1) - [@KronicDeth](https://github.com/KronicDeth)
+  * Add missing top-level files to extras:
+    * `CHANGELOG.md`
+    * `CODE_OF_CONDUCT.md`
+    * `CONTRIBUTING.md`
+    * `LICENSE.md`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Changelog](#changelog)
+  - [v1.1.0](#v110)
+    - [Enhancements](#enhancements)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+# Changelog
+
+## v1.1.0
+
+### Enhancements
+* [#1](https://github.com/C-S-D/calcinator/pull/1) - Expose `attribute_to_field` that was used in `Calcinator.Resources.Sort` as it is useful in other places instead of using `String.to_existing_atom`, which doesn't handle the hyphenation and can fail if the atom hasn't been loaded yet. - [@KronicDeth](https://github.com/KronicDeth)

--- a/lib/calcinator/resources.ex
+++ b/lib/calcinator/resources.ex
@@ -151,4 +151,31 @@ defmodule Calcinator.Resources do
       errors.
   """
   @callback update(Ecto.Changeset.t, query_options) :: {:ok, struct} | {:error, Ecto.Changeset.t}
+
+  # Functions
+
+
+  @doc """
+  Converts the attribute to a field if a corresponding field existings in `ecto_schema_module`
+   
+  ## Returns
+   
+    * `{:ok, field}` - `attribute` with `-` has the corresponding `field` with `_` in `ecto_schema_module`
+    * `{:error, attribute}` - `attribute` does not have corresponding field in `ecto_schema_module`
+   
+  """
+  @lint {Credo.Check.Refactor.PipeChainStart, false}
+  def attribute_to_field(attribute, ecto_schema_module) when is_binary(attribute) and is_atom(ecto_schema_module) do
+    field_string = String.replace(attribute, "-", "_")
+
+    for(potential_field <- ecto_schema_module.__schema__(:fields),
+        potential_field_string = to_string(potential_field),
+        potential_field_string == field_string, do: potential_field)
+    |> case do
+      [field] ->
+        {:ok, field}
+      [] ->
+        {:error, attribute}
+    end
+  end
 end

--- a/lib/calcinator/resources/sort.ex
+++ b/lib/calcinator/resources/sort.ex
@@ -6,6 +6,8 @@ defmodule Calcinator.Resources.Sort do
   alias Alembic.{Document, Error, Fetch.Includes, Source}
   alias Calcinator.Resources
 
+  import Resources, only: [attribute_to_field: 2]
+
   # Struct
 
   defstruct field: nil,
@@ -355,7 +357,6 @@ defmodule Calcinator.Resources.Sort do
 
   defp attribute_error_result(sort), do: {:error, attribute_error_document(sort)}
 
-  @lint {Credo.Check.Refactor.PipeChainStart, false}
   defp field(
          %{
            association: nil,
@@ -365,15 +366,12 @@ defmodule Calcinator.Resources.Sort do
            }
          }
        ) do
-    field_string = String.replace(attribute, "-", "_")
-
-    for(potential_field <- ecto_schema_module.__schema__(:fields),
-        potential_field_string = to_string(potential_field),
-        potential_field_string == field_string, do: potential_field)
+    attribute
+    |> attribute_to_field(ecto_schema_module)
     |> case do
-      [field] ->
+      {:ok, field} ->
         {:ok, field}
-      [] ->
+      {:error, ^attribute} ->
         attribute_error_result(sort)
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -18,7 +18,7 @@ defmodule Calcinator.Mixfile do
       ],
       source_url: "https://github.com/C-S-D/calcinator",
       start_permanent: Mix.env == :prod,
-      version: "1.0.0"
+      version: "1.1.0"
     ]
   end
 
@@ -61,7 +61,7 @@ defmodule Calcinator.Mixfile do
 
   defp docs do
     [
-      extras: ~w(README.md)
+      extras: ~w(CHANGELOG.md README.md)
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -61,7 +61,7 @@ defmodule Calcinator.Mixfile do
 
   defp docs do
     [
-      extras: ~w(CHANGELOG.md README.md)
+      extras: ~w(CHANGELOG.md CODE_OF_CONDUCT.md CONTRIBUTING.md LICENSE.md README.md)
     ]
   end
 

--- a/test/calcinator/resources_test.exs
+++ b/test/calcinator/resources_test.exs
@@ -1,0 +1,5 @@
+defmodule Calcinator.ResourcesTest do
+  use ExUnit.Case, async: true
+
+  doctest Calcinator.Resources
+end


### PR DESCRIPTION
# Changelog
## Enhancements
* Expose `attribute_to_field` that was used in `Calcinator.Resources.Sort` as it is useful in other places instead of using `String.to_existing_atom`, which doesn't handle the hyphenation and can fail if the atom hasn't been loaded yet.

## Bug Fixes
* Add missing top-level files to extras:
  * `CHANGELOG.md`
  * `CODE_OF_CONDUCT.md`
  * `CONTRIBUTING.md`
  * `LICENSE.md`