### PR TITLE
attribute_to_field should work with virtual fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,24 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [Changelog](#changelog)
-  - [v1.1.0](#v110)
+  - [v1.2.0](#v120)
     - [Enhancements](#enhancements)
+    - [Bug Fixes](#bug-fixes)
+  - [v1.1.0](#v110)
+    - [Enhancements](#enhancements-1)
+    - [Bug Fixes](#bug-fixes-1)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 # Changelog
+
+## v1.2.0
+
+### Enhancements
+* [#2](https://github.com/C-S-D/calcinator/pull/2) - Doctests for `Calcinator.Resources.attribute_to_field/2` - [@KronicDeth](https://github.com/KronicDeth)
+
+### Bug Fixes
+* [#2](https://github.com/C-S-D/calcinator/pull/2) - `Calcinator.Resources.attribute_to_field/2` now works with virtual fields. - [@KronicDeth](https://github.com/KronicDeth)
 
 ## v1.1.0
 

--- a/mix.exs
+++ b/mix.exs
@@ -18,7 +18,7 @@ defmodule Calcinator.Mixfile do
       ],
       source_url: "https://github.com/C-S-D/calcinator",
       start_permanent: Mix.env == :prod,
-      version: "1.1.0"
+      version: "1.2.0"
     ]
   end
 

--- a/test/support/calcinator/resources/test_author.ex
+++ b/test/support/calcinator/resources/test_author.ex
@@ -7,6 +7,8 @@ defmodule Calcinator.Resources.TestAuthor do
 
   schema "authors" do
     field :name, :string
+    field :password, :string, virtual: true
+    field :password_confirmation, :string, virtual: true
 
     has_many :posts, Calcinator.Resources.TestPost, foreign_key: :author_id
   end


### PR DESCRIPTION
# Changelog
## Enhancements
* Doctests for `Calcinator.Resources.attribute_to_field/2`

## Bug Fixes
* `Calcinator.Resources.attribute_to_field/2` now works with virtual fields.