### PR TITLE
{:error, :ownership} at all levels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,23 +3,38 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [Changelog](#changelog)
-  - [v1.4.0](#v140)
-  - [v1.3.0](#v130)
+  - [v1.5.0](#v150)
     - [Enhancements](#enhancements)
     - [Bug Fixes](#bug-fixes)
-  - [v1.2.0](#v120)
+  - [v1.4.0](#v140)
     - [Enhancements](#enhancements-1)
-    - [Bug Fixes](#bug-fixes-1)
-  - [v1.1.0](#v110)
+  - [v1.3.0](#v130)
     - [Enhancements](#enhancements-2)
+    - [Bug Fixes](#bug-fixes-1)
+  - [v1.2.0](#v120)
+    - [Enhancements](#enhancements-3)
     - [Bug Fixes](#bug-fixes-2)
+  - [v1.1.0](#v110)
+    - [Enhancements](#enhancements-4)
+    - [Bug Fixes](#bug-fixes-3)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 # Changelog
 
+## v1.5.0
+
+### Enhancements
+* [#6](https://github.com/C-S-D/calcinator/pull/6) - [@KronicDeth](https://github.com/KronicDeth)
+  * Add `{:error, :ownership}` ∀ `Calcinator.Resources` callbacks
+  * Add `{:error, :ownership}` ∀ `Calcinator` actions
+
+### Bug Fixes
+* [#6](https://github.com/C-S-D/calcinator/pull/6) - Previously `get` and `list` were the only `Calcinator.Resources.Ecto.Repo` functions that converted `DBConnection.OwnershipError` to `{:error, :ownership}`, but the other `Ecto.Repo` calls could also throw the Error, so all calls need to be protected for consistency. - [@KronicDeth](https://github.com/KronicDeth)
+
 ## v1.4.0
 
+### Enhancements
 * [#4](https://github.com/C-S-D/calcinator/pull/4) - `use Calcinator.Resources.Ecto.Repo` will define the callbacks for `Calcinator.Resources` backed by an `Ecto.Repo`.  The only callbacks that are required then are `ecto_schema_module/0`, `full_associations/1` and `repo/0`. - [@KronicDeth](https://github.com/KronicDeth)
 * [#5](https://github.com/C-S-D/calcinator/pull/5) - [@KronicDeth](https://github.com/KronicDeth)
   * Update to `credo` `0.5.3`

--- a/lib/calcinator.ex
+++ b/lib/calcinator.ex
@@ -135,6 +135,7 @@ defmodule Calcinator do
 
   ## Returns
 
+    * `{:error, :ownership}` - connection to backing store was not owned by the calling process
     * `{:error, :unauthorized}` - if `state` `authorization_module` `can?(subject, :create, ecto_schema_module)` or
       `can?(subject, :create, %Ecto.Changeset{})` returns `false`
     * `{:error, Alembic.Document.t}` - if `params` is not a valid JSONAPI document
@@ -142,7 +143,8 @@ defmodule Calcinator do
     * `{:ok, rendereded}` - rendered view of created resource
 
   """
-  @spec create(t, params) :: {:error, :unauthorized} |
+  @spec create(t, params) :: {:error, :ownership} |
+                             {:error, :unauthorized} |
                              {:error, Document.t} |
                              {:error, Ecto.Changeset.t} |
                              {:ok, rendered}
@@ -179,13 +181,17 @@ defmodule Calcinator do
   ## Returns
 
     * `{:error, {:not_found, "id"}}` - The "id" did not correspond to resource in the backing store
+    * `{:error, :ownership}` - connection to backing store was not owned by the calling process
     * `{:error, :unauthorized}` - The `state` `subject` is not authorized to delete the resource
     * `{:error, Ecto.Changeset.t}` - the deletion failed with the errors in `Ecto.Changeset.t`
     * `:ok` - resource was successfully deleted
 
   """
-  @spec delete(t, params) ::
-        {:error, {:not_found, parameter}} | {:error, :unauthorized} | {:error, Ecto.Changeset.t} | :ok
+  @spec delete(t, params) :: :ok |
+                             {:error, {:not_found, parameter}} |
+                             {:error, :ownership} |
+                             {:error, :unauthorized} |
+                             {:error, Ecto.Changeset.t}
   def delete(state = %__MODULE__{}, params) do
     with :ok <- allow_sandbox_access(state, params),
          {:ok, target} <- get(state, params),
@@ -212,12 +218,13 @@ defmodule Calcinator do
 
     * `{:error, {:not_found, id_key}}` - The value of the `id_key` key in `params` did not correspond to a resource in
       the backing store.
+    * `{:error, :ownership}` - connection to backing store was not owned by the calling process
     * `{:error, :unauthorized}` - if the either the source or related resource cannot be shown
     * `{:ok, rendered}` - rendered view of related resource
 
   """
   @spec get_related_resource(t, params, map) ::
-        {:error, {:not_found, parameter}} | {:error, :unauthorized} | {:ok, rendered}
+        {:error, {:not_found, parameter}} | {:error, :ownership} | {:error, :unauthorized} | {:ok, rendered}
   def get_related_resource(
         state = %__MODULE__{},
         params,
@@ -242,6 +249,7 @@ defmodule Calcinator do
 
   ## Returns
 
+    * `{:error, :ownership}` - connection to backing store was not owned by the calling process
     * `{:error, :timeout}` - if the backing store for `state` `resources_module` times out when calling `list/1`.
     * `{:error, :unauthorized}` - if `state` `authorization_module` `can?(subject, :index, ecto_schema_module)` returns
       `false`
@@ -287,13 +295,17 @@ defmodule Calcinator do
   ## Returns
 
     * `{:error, {:not_found, "id"}}` - The "id" did not correspond to resource in the backing store
+    * `{:error, :ownership}` - connection to backing store was not owned by the calling process
     * `{:error, :unauthorized}` - `state` `authorization_module` `can?(subject, :show, got)` returns `false`
     * `{:error, Alembic.Document.t}` - `params` is not valid JSONAPI
     * `{:ok, rendered}` - rendered resource
 
   """
-  @spec show(t, params) ::
-        {:error, {:not_found, parameter}} | {:error, :unauthorized} | {:error, Document.t} | {:ok, rendered}
+  @spec show(t, params) :: {:error, {:not_found, parameter}} |
+                           {:error, :ownership} |
+                           {:error, :unauthorized} |
+                           {:error, Document.t} |
+                           {:ok, rendered}
   def show(state = %__MODULE__{subject: subject, view_module: view_module}, params = %{"id" => _}) do
     with :ok <- allow_sandbox_access(state, params),
          {:ok, shown} <- get(state, params),
@@ -319,12 +331,13 @@ defmodule Calcinator do
 
     * `{:error, {:not_found, id_key}}` - The value of the `id_key` key in `params` did not correspond to a resource in
       the backing store.
+    * `{:error, :ownership}` - connection to backing store was not owned by the calling process
     * `{:error, :unauthorized}` - if the either the source or related resource cannot be shown
     * `{:ok, rendered}` - rendered view of relationship
 
   """
   @spec show_relationship(t, params, map) ::
-        {:error, {:not_found, parameter}} | {:error, :unauthorized} | {:ok, rendered}
+        {:error, {:not_found, parameter}} | {:error, :ownership} | {:error, :unauthorized} | {:ok, rendered}
   def show_relationship(
         state = %__MODULE__{},
         params,
@@ -352,6 +365,7 @@ defmodule Calcinator do
       Try again later or call support.
     * `{:error, {:not_found, "id"}}` - get failed or update failed because the resource was deleted between the get and
       update.
+    * `{:error, :ownership}` - connection to backing store was not owned by the calling process
     * `{:error, :unauthorized}` - the resource either can't be shown or can't be updated
     * `{:error, Alembic.Document.t}` - the `params` are not valid JSONAPI
     * `{:error, Ecto.Changeset.t}` - validations error when updating
@@ -360,6 +374,7 @@ defmodule Calcinator do
   """
   @spec update(t, params) :: {:error, :bad_gateway} |
                              {:error, {:not_found, parameter}} |
+                             {:error, :ownership} |
                              {:error, :unauthorized} |
                              {:error, Document.t} |
                              {:error, Ecto.Changeset.t} |

--- a/lib/calcinator/resources.ex
+++ b/lib/calcinator/resources.ex
@@ -67,9 +67,10 @@ defmodule Calcinator.Resources do
   # Returns
 
     * `{:ok, struct}` - the delete succeeded and the returned struct is the state before delete
+    * `{:error, :ownership}` - connection to backing store was not owned by the calling process
     * `{:error, Ecto.Changeset.t}` - errors while deleting the `struct`.  `Ecto.Changeset.t` `errors` contains errors.
   """
-  @callback delete(struct) :: {:ok, struct} | {:error, Ecto.Changeset.t}
+  @callback delete(struct) :: {:ok, struct} | {:error, :ownership} | {:error, Ecto.Changeset.t}
 
   @doc """
   Gets a single `struct`
@@ -78,21 +79,23 @@ defmodule Calcinator.Resources do
 
     * `{:ok, struct}` - `id` was found.
     * `{:error, :not_found}` - `id` was not found.
+    * `{:error, :ownership}` - connection to backing store was not owned by the calling process
     * `{:error, :timeout}` - timeout occured while getting `id` from backing store .
     * `{:error, reason}` - an error occurred with the backing store for `reason` that is backing store specific.
 
   """
   @callback get(id, query_options) ::
-            {:ok, struct} | {:error, :not_found} | {:error, :timeout} | {:error, reason :: term}
+            {:ok, struct} | {:error, :not_found} | {:error, :ownership} | {:error, :timeout} | {:error, reason :: term}
 
   @doc """
   Inserts `changeset` into a single new `struct`
 
   # Returns
     * `{:ok, struct}` - `changeset` was inserted into `struct`
+    * `{:error, :ownership}` - connection to backing store was not owned by the calling process
     * `{:error, Ecto.Changeset.t}` - insert failed.  `Ecto.Changeset.t` `errors` contain errors.
   """
-  @callback insert(Ecto.Changeset.t, query_options) :: {:ok, struct} | {:error, Ecto.Changeset.t}
+  @callback insert(Ecto.Changeset.t, query_options) :: {:ok, struct} | {:error, :ownership} | {:error, Ecto.Changeset.t}
 
   @doc """
   Inserts `params` into a single new `struct`
@@ -100,10 +103,11 @@ defmodule Calcinator.Resources do
   # Returns
 
     * `{:ok, struct}` - params were inserted into `struct`
+    * `{:error, :ownership}` - connection to backing store was not owned by the calling process
     * `{:error, Ecto.Changeset.t}` - insert failed.  `Ecto.Changeset.t` `errors` contain errors.
 
   """
-  @callback insert(params, query_options) :: {:ok, struct} | {:error, Ecto.Changeset.t}
+  @callback insert(params, query_options) :: {:ok, struct} | {:error, :ownership} | {:error, Ecto.Changeset.t}
 
   @doc """
   Gets a list of `struct`s.
@@ -112,11 +116,15 @@ defmodule Calcinator.Resources do
 
     * `{:ok, [resource], nil}` - all resources matching query
     * `{:ok, [resource], pagination}` - page of resources matching query
+    * `{:error, :ownership}` - connection to backing store was not owned by the calling process
     * `{:error, :timeout}` - timeout occured while getting resources from backing store .
     * `{:error, reason}` - an error occurred with the backing store for `reason` that is backing store specific.
 
   """
-  @callback list(query_options) :: {:ok, [struct], pagination | nil} | {:error, :timeout} | {:error, reason :: term}
+  @callback list(query_options) :: {:ok, [struct], pagination | nil} |
+                                   {:error, :ownership} |
+                                   {:error, :timeout} |
+                                   {:error, reason :: term}
 
   @doc """
   # Returns
@@ -135,11 +143,15 @@ defmodule Calcinator.Resources do
     * `{:error, Ecto.Changeset.t}` - errors while updating `struct` with `params`.  `Ecto.Changeset.t` `errors` contains
       errors.
     * `{:error, :bad_gateway}` - error in backing store that cannot be represented as another type of error
+    * `{:error, :ownership}` - connection to backing store was not owned by the calling process
     * `{:error, :not_found}` - the resource in the changeset was not found and so cannot be updated.  This may mean that
       the resource was deleted with `delete/1` after the `get/2` or `list/1` returned.
   """
-  @callback update(resource :: Ecto.Schema.t, params, query_options) ::
-            {:ok, struct} | {:error, Ecto.Changeset.t} | {:error, :bad_gateway} | {:error, :not_found}
+  @callback update(resource :: Ecto.Schema.t, params, query_options) :: {:ok, struct} |
+                                                                        {:error, Ecto.Changeset.t} |
+                                                                        {:error, :bad_gateway} |
+                                                                        {:error, :ownership} |
+                                                                        {:error, :not_found}
 
   @doc """
   Applies updates in `changeset`
@@ -147,10 +159,11 @@ defmodule Calcinator.Resources do
   # Returns
 
     * `{:ok, struct}` - the update succeeded and the returned `struct` contains the updates
-    * `{error, Ecto.Changeset.t}` - errors while updating `struct` with `params`.  `Ecto.Changeset.t` `errors` contains
+    * `{:error, :ownership}` - connection to backing store was not owned by the calling process
+    * `{:error, Ecto.Changeset.t}` - errors while updating `struct` with `params`.  `Ecto.Changeset.t` `errors` contains
       errors.
   """
-  @callback update(Ecto.Changeset.t, query_options) :: {:ok, struct} | {:error, Ecto.Changeset.t}
+  @callback update(Ecto.Changeset.t, query_options) :: {:ok, struct} | {:error, :ownership} | {:error, Ecto.Changeset.t}
 
   # Functions
 

--- a/mix.exs
+++ b/mix.exs
@@ -18,7 +18,7 @@ defmodule Calcinator.Mixfile do
       ],
       source_url: "https://github.com/C-S-D/calcinator",
       start_permanent: Mix.env == :prod,
-      version: "1.4.0"
+      version: "1.5.0"
     ]
   end
 


### PR DESCRIPTION
# Changelog
## Enhancements
* Add `{:error, :ownership}` ∀ `Calcinator.Resources` callbacks
* Add `{:error, :ownership}` ∀ `Calcinator` actions

## Bug Fixes
* Previously `get` and `list` were the only `Calcinator.Resources.Ecto.Repo` functions that converted `DBConnection.OwnershipError` to `{:error, :ownership}`, but the other `Ecto.Repo` calls could also throw the Error, so all calls need to be protected for consistency.
