### PR TITLE
Controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
   * `use Calcinator.Controller` can be used inside a `Phoenix` controller to define JSONAPI actions.
   * `Calcinator.Controller.Error` defines functions for JSONAPI formatted errors that `Calcinator.Controller` may respond with.
   * Document how to use `Calcinator.Controller` to access `Retort.Client.Generic` backed `Calcinator.Resource`
+  * Document how to use `Calcinator.Controller` to access `Calcinator.Resources.Ecto.Repo`
 
 ## v1.5.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@
 * [#8](https://github.com/C-S-D/calcinator/pull/8) - [@KronicDeth](https://github.com/KronicDeth)
   * `use Calcinator.Controller` can be used inside a `Phoenix` controller to define JSONAPI actions.
   * `Calcinator.Controller.Error` defines functions for JSONAPI formatted errors that `Calcinator.Controller` may respond with.
-
+  * Document how to use `Calcinator.Controller` to access `Retort.Client.Generic` backed `Calcinator.Resource`
 
 ## v1.5.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,26 +3,36 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [Changelog](#changelog)
+  - [v1.6.0](#v160)
+    - [Enhancements](#enhancements)
   - [v1.5.1](#v151)
     - [Bug Fixes](#bug-fixes)
   - [v1.5.0](#v150)
-    - [Enhancements](#enhancements)
+    - [Enhancements](#enhancements-1)
     - [Bug Fixes](#bug-fixes-1)
   - [v1.4.0](#v140)
-    - [Enhancements](#enhancements-1)
-  - [v1.3.0](#v130)
     - [Enhancements](#enhancements-2)
+  - [v1.3.0](#v130)
+    - [Enhancements](#enhancements-3)
     - [Bug Fixes](#bug-fixes-2)
   - [v1.2.0](#v120)
-    - [Enhancements](#enhancements-3)
+    - [Enhancements](#enhancements-4)
     - [Bug Fixes](#bug-fixes-3)
   - [v1.1.0](#v110)
-    - [Enhancements](#enhancements-4)
+    - [Enhancements](#enhancements-5)
     - [Bug Fixes](#bug-fixes-4)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 # Changelog
+
+## v1.6.0
+
+### Enhancements
+* [#8](https://github.com/C-S-D/calcinator/pull/8) - [@KronicDeth](https://github.com/KronicDeth)
+  * `use Calcinator.Controller` can be used inside a `Phoenix` controller to define JSONAPI actions.
+  * `Calcinator.Controller.Error` defines functions for JSONAPI formatted errors that `Calcinator.Controller` may respond with.
+
 
 ## v1.5.1
 

--- a/README.md
+++ b/README.md
@@ -68,3 +68,232 @@ If [available in Hex](https://hex.pm/docs/publish), the package can be installed
     end
     ```
 
+## Usage
+
+### Phoenix
+
+`Calcinator.Controller` uses `Calcinator.Resources`, which is transport-agnostic, so you can use it to access multiple
+backing stores.  CSD itself, uses it to access PostgreSQL database owned by the project using `Ecto` and to access
+remote data over RabbitMQ.
+
+#### RabbitMQ
+
+If you want to use `Calcinator` over RabbitMQ, use [`Retort`](https://github.com/C-S-D/retort): it's
+[`Retort.Resources`](https://hexdocs.pm/retort/Retort.Resources.html) implements the `Calcinator.Resources` behaviour.
+
+##### `Ecto.Schema` modules
+
+`RemoteApp.Author` and `RemoteApp.Post` are standard `use Ecto.Schema` modules.  `RemoteApp` is a separate OTP
+application in the umbrella project.
+
+```elixir
+defmodule RemoteApp.Author do
+  @moduledoc """
+  The author of `RemoteApp.Post`s
+  """
+
+  use Ecto.Schema
+
+  schema "authors" do
+    field :name, :string
+    field :password, :string, virtual: true
+    field :password_confirmation, :string, virtual: true
+
+    timestamps
+
+    has_many :posts, RemoteApp.Post, foreign_key: :author_id
+  end
+end
+```
+-- `apps/remote_app/lib/remote_app/author.ex`
+
+```elixir
+defmodule RemoteApp.Author do
+  @moduledoc """
+  Posts by a `RemoteApp.Author`.
+  """
+
+  use Ecto.Schema
+
+  schema "posts" do
+    field :text, :string
+
+    timestamps
+
+    belongs_to :author, RemoteApp.Author
+  end
+end
+```
+-- `apps/remote_app/lib/remote_app/post.ex`
+
+##### Client module
+
+Define a module to setup a `Retort.Generic.Client` (you can also inline this at `Client.Post.start_link()` below, but
+we find the module useful for tests.
+
+```elixir
+defmodule RemoteApp.Client.Post do
+  @moduledoc """
+  Client for accessing Posts on remote-server
+  """
+
+  alias RemoteApp.{Author, Post}
+
+  # Functions
+
+  def queue, do: "remote_server_post"
+
+  def start_link(opts \\ []) do
+    Retort.Client.Generic.start_link(
+      opts ++ [
+        ecto_schema_module_by_type: %{
+          "authors" => Author,
+          "posts" => Post
+        },
+        queue: queue,
+        type: "posts"
+      ]
+    )
+  end
+end
+```
+-- `apps/remote_app/lib/remote_app/client/post.ex`
+
+##### Resources module
+
+Define a module that `use Retort.Resources` to get the `Ecto.Schema` structs using `Retort.Generic.Client`
+
+```elixir
+defmodule RemoteApp.Posts do
+  @moduledoc """
+  Retrieves `%RemoteApp.Post{}` over RPC
+  """
+
+  alias RemoteApp.Client
+  alias RemoteApp.Post
+
+  require Ecto.Query
+
+  import Ecto.Changeset, only: [cast: 3]
+
+  use Retort.Resources
+
+  # Constants
+
+  @default_timeout 5_000 # milliseconds
+
+  @optional_fields ~w()a
+  @required_fields ~w()a
+
+  @allowed_fields @optional_fields ++ @required_fields
+
+  # Functions
+
+  ## Retort.Resources callbacks
+
+  def association_to_include(:author), do: "author"
+
+  def client_start_link() do
+    __MODULE__
+    |> Retort.Resources.client_start_link_options()
+    |> Client.Post.start_link()
+  end
+
+  def ecto_schema_module(), do: Post
+
+  ## Resources callbacks
+
+  @doc """
+  Creates a changeset that updates `post` with `params`.
+  """
+  @spec changeset(%Post{}, Resoures.params) :: Ecto.Changeset.t
+  def changeset(post, params), do: cast(post, params, @allowed_fields)
+
+  def sandboxed?(), do: LocalApp.Repo.sandboxed?()
+end
+```
+-- `apps/remote_app/lib/remote_app/posts`
+
+##### View Module
+
+`Calcinator` relies on `JaSerializer` to define view module
+
+```elixir
+defmodule LocalAppWeb.PostView do
+  @moduledoc """
+  Handles encoding the Post model into JSON:API format.
+  """
+
+  alias RemoteApp.Post
+
+  use LocalAppWeb.Web, :view
+  use Calcinator.JaSerializer.PhoenixView,
+      phoenix_view_module: __MODULE__
+
+  # Attributes
+
+  attributes ~w(inserted_at
+                text
+                updated_at)a
+
+  # Location
+
+  location "/posts/:id"
+
+  # Relationships
+
+  has_one :author,
+          serializer: LocalAppWeb.AuthorView
+
+  # Functions
+
+  def relationships(post = %Post{}, conn) do
+    partner
+    |> super(conn)
+    |> Enum.filter(relationships_filter(post))
+    |> Enum.into(%{})
+  end
+
+  def type(_data, _conn), do: "posts"
+
+  ## Private Functions
+
+  def relationships_filter(%Post{author: %Ecto.Association.NotLoaded{}}) do
+    fn {name, _relationship} ->
+      name != :author
+    end
+  end
+
+  def relationships_filter(_) do
+    fn {_name, _relationship} ->
+      true
+    end
+  end
+end
+```
+--- `apps/local_app_web/lib/local_app_web/post_view.ex`
+
+##### Controller Module
+
+```elixir
+defmodule LocalAppWeb.PostController do
+  @moduledoc """
+  Allows reading of Post that are fetched from Remote Server via RPC.
+  """
+
+  use LocalAppWeb.Web, :controller
+
+  alias InterpreterServerWeb.Controller
+
+  use Controller.Resources,
+      actions: ~w(index show)a,
+      configuration: %Calcinator{
+        authorization_module: LocalAppWeb.Authorization,
+        ecto_schema_module: RemoteApp.Post,
+        resources_module: RemoteApp.Posts,
+        view_module: LocalAppWeb.PostView
+      }
+end
+```
+--- `apps/local_app_web/lib/local_app_web/post_controller.ex`
+

--- a/config/.credo.exs
+++ b/config/.credo.exs
@@ -2,7 +2,7 @@
   configs: [
     %{
       checks: [
-        {Credo.Check.Design.AliasUsage, excluded_namespaces: ~w(Meta)},
+        {Credo.Check.Design.AliasUsage, excluded_lastnames: ~w(Controller), excluded_namespaces: ~w(Meta)},
         {Credo.Check.Readability.MaxLineLength, priority: :low, max_length: 120}
       ],
       files: %{

--- a/lib/calcinator/controller.ex
+++ b/lib/calcinator/controller.ex
@@ -7,6 +7,7 @@ defmodule Calcinator.Controller do
   alias Alembic.Document
   alias Plug.Conn
 
+  import Calcinator.Controller.Error
   import Conn
 
   # Macros

--- a/lib/calcinator/controller/error.ex
+++ b/lib/calcinator/controller/error.ex
@@ -1,0 +1,103 @@
+defmodule Calcinator.Controller.Error do
+  @moduledoc """
+  Errors returned by `Calcinator.Controller`.  Public, so that other controllers not using `Calcinator.Controller` can
+  have same format for errors.
+  """
+
+  alias Alembic.{Document, Error, Source}
+  alias Calcinator.ChangesetView
+  alias Plug.Conn
+
+  import Conn, only: [halt: 1, put_resp_content_type: 2, put_status: 2]
+  import Phoenix.Controller, only: [json: 2, render: 4]
+
+  @doc """
+  Retort returned a 500 JSONAPI error inside a 422 JSONRPC error.
+  """
+  @spec bad_gateway(Conn.t) :: Conn.t
+  def bad_gateway(conn) do
+    conn
+    |> put_status(:bad_gateway)
+    |> put_resp_content_type("application/vnd.api+json")
+    |> json(
+         %Document{
+           errors: [
+             %Error{
+               status: "502",
+               title: "Bad Gateway"
+             }
+           ]
+         }
+       )
+  end
+
+  @doc """
+  The current resource or action is forbidden to the authenticated user
+  """
+  @spec forbidden(Conn.t) :: Conn.t
+  def forbidden(conn) do
+    conn
+    |> put_status(:forbidden)
+    |> put_resp_content_type("application/vnd.api+json")
+    |> json(
+         %Document{
+           errors: [
+             %Error{
+               detail: "You do not have permission for this resource.",
+               status: "403",
+               title: "Forbidden"
+             }
+           ]
+         }
+       )
+    |> halt()
+  end
+
+  @doc """
+  Puts 404 Resource Not Found JSONAPI error in `conn` with `parameter` as the source parameter.
+  """
+  @spec not_found(Conn.t, String.t) :: Conn.t
+  def not_found(conn, parameter) do
+    conn
+    |> put_status(:not_found)
+    |> put_resp_content_type("application/vnd.api+json")
+    |> json(
+         %Document{
+           errors: [
+             %Error{
+               source: %Source{
+                 parameter: parameter
+               },
+               status: "404",
+               title: "Resource Not Found"
+             }
+           ]
+         }
+       )
+    |> halt()
+  end
+
+  @doc """
+  Renders `changeset` as an error object using the `Calcinator.ChangesetView`.
+  """
+  @spec render_changeset_error(Conn.t, Ecto.Changeset.t) :: Conn.t
+  def render_changeset_error(conn, changeset) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> put_resp_content_type("application/vnd.api+json")
+    |> render(ChangesetView, "error-object.json", changeset)
+    |> halt()
+  end
+
+  @doc """
+  Renders `encodable` as JSON after `put_jsonapi_and_status` on the `conn`.
+  """
+  @spec render_json(Conn.t, term, atom) :: Conn.t
+  def render_json(conn, encodable, status) do
+    conn
+    |> put_status(status)
+    |> put_resp_content_type("application/vnd.api+json")
+    |> json(encodable)
+    |> halt()
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -18,7 +18,7 @@ defmodule Calcinator.Mixfile do
       ],
       source_url: "https://github.com/C-S-D/calcinator",
       start_permanent: Mix.env == :prod,
-      version: "1.5.1"
+      version: "1.6.0"
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -49,7 +49,9 @@ defmodule Calcinator.Mixfile do
       {:ex_doc, "~> 0.14.0", only: [:dev, :test]},
       {:ja_serializer, "~> 0.11.0"},
       # JUnit formatter, so that CircleCI can consume test output for CircleCI UI
-      {:junit_formatter, "~> 1.0", only: :test}
+      {:junit_formatter, "~> 1.0", only: :test},
+      # Phoenix.Controller is used in Calcinator.Controller.Error
+      {:phoenix, "~> 1.0", optional: true}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -10,6 +10,8 @@
   "ja_serializer": {:hex, :ja_serializer, "0.11.2", "952b59b480e656e0bd991c5822dda4dfc6c507f1c55d6eaea363cd84e6002e2c", [:mix], [{:inflex, "~> 1.4", [hex: :inflex, optional: false]}, {:plug, "> 1.0.0", [hex: :plug, optional: false]}, {:poison, "~> 1.4 or ~> 2.0", [hex: :poison, optional: false]}, {:scrivener, "~> 1.2 or ~> 2.0", [hex: :scrivener, optional: true]}]},
   "junit_formatter": {:hex, :junit_formatter, "1.2.0", "ddd0be915b11185e332bb103efb14c2edbcd5bbb989ff64c69261c8dbc0d4fba", [:mix], []},
   "mime": {:hex, :mime, "1.0.1", "05c393850524767d13a53627df71beeebb016205eb43bfbd92d14d24ec7a1b51", [:mix], []},
+  "phoenix": {:hex, :phoenix, "1.2.1", "6dc592249ab73c67575769765b66ad164ad25d83defa3492dc6ae269bd2a68ab", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, optional: true]}, {:phoenix_pubsub, "~> 1.0", [hex: :phoenix_pubsub, optional: false]}, {:plug, "~> 1.1", [hex: :plug, optional: false]}, {:poison, "~> 1.5 or ~> 2.0", [hex: :poison, optional: false]}]},
+  "phoenix_pubsub": {:hex, :phoenix_pubsub, "1.0.1", "c10ddf6237007c804bf2b8f3c4d5b99009b42eca3a0dfac04ea2d8001186056a", [:mix], []},
   "plug": {:hex, :plug, "1.3.0", "6e2b01afc5db3fd011ca4a16efd9cb424528c157c30a44a0186bcc92c7b2e8f3", [:mix], [{:cowboy, "~> 1.0.1 or ~> 1.1", [hex: :cowboy, optional: true]}, {:mime, "~> 1.0", [hex: :mime, optional: false]}]},
   "poison": {:hex, :poison, "2.2.0", "4763b69a8a77bd77d26f477d196428b741261a761257ff1cf92753a0d4d24a63", [:mix], []},
   "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], []}}


### PR DESCRIPTION
# Changelog
## Enhancements
* `use Calcinator.Controller` can be used inside a `Phoenix` controller to define JSONAPI actions.
* `Calcinator.Controller.Error` defines functions for JSONAPI formatted errors that `Calcinator.Controller` may respond with.
* Document how to use `Calcinator.Controller` to access `Retort.Client.Generic` backed `Calcinator.Resource`
* Document how to use `Calcinator.Controller` to access `Calcinator.Resources.Ecto.Repo`
