### PR TITLE
Missing ecto schema module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,14 @@
 
 # Changelog
 
+## v1.7.0
+
+### Enhancements
+* [#9](https://github.com/C-S-D/calcinator/pull/9) - Examples for how to `use Calcinator.Resources.Ecto.Repo` in `Calcinator.Resources.Ecto.Repo`'s `@moduledoc` - [@KronicDeth](https://github.com/KronicDeth)
+
+### Bug Fixes
+* [#9](https://github.com/C-S-D/calcinator/pull/9) - Add missing `ecto_schema_module/0` callback to `README` example of `use Calcinator.Resources.Ecto.Repo` - [@KronicDeth](https://github.com/KronicDeth)
+
 ## v1.6.0
 
 ### Enhancements

--- a/README.md
+++ b/README.md
@@ -139,9 +139,12 @@ defmodule MyApp.Posts do
 
   ## Calcinator.Resources.Ecto.Repo callbacks
 
-  def repo, do: MyApp.Repo
+  def ecto_schema_module(), do: MyApp.Post
+
+  def repo(), do: MyApp.Repo
 end
 ```
+
 ##### View Module
 
 `Calcinator` relies on `JaSerializer` to define view module

--- a/lib/calcinator/resources/ecto/repo.ex
+++ b/lib/calcinator/resources/ecto/repo.ex
@@ -1,6 +1,50 @@
 defmodule Calcinator.Resources.Ecto.Repo do
   @moduledoc """
   Default callbacks for `Calcinator.Resources` behaviour when backed by a single `Ecto.Repo`
+
+  If you don't have any default loaded associations, you only need to define `ecto_schema_module/0` and `repo/0`
+
+      defmodule MyApp.Posts do
+        @moduledoc \"""
+        Retrieves `%MyApp.Post{}` from `MyApp.Repo`
+        \"""
+
+        use Calcinator.Resources.Ecto.Repo
+
+        # Functions
+
+        ## Calcinator.Resources.Ecto.Repo callbacks
+
+        def ecto_schema_module(), do: MyApp.Post
+
+        def repo(), do: MyApp.Repo
+      end
+
+  If you need to override the loaded associations also override `full_associations/1`
+
+       defmodule MyApp.Posts do
+        @moduledoc \"""
+        Retrieves `%MyApp.Post{}` from `MyApp.Repo`
+        \"""
+
+        use Calcinator.Resources.Ecto.Repo
+
+        # Functions
+
+        ## Calcinator.Resources.Ecto.Repo callbacks
+
+        def ecto_schema_module(), do: MyApp.Post
+
+        @doc \"""
+        Always loads post author
+        \"""
+        def full_associations(query_options) do
+          [:author | super(query_options)]
+        end
+
+        def repo(), do: MyApp.Repo
+      end
+
   """
 
   alias Ecto.{Adapters.SQL.Sandbox, Query}

--- a/mix.exs
+++ b/mix.exs
@@ -18,7 +18,7 @@ defmodule Calcinator.Mixfile do
       ],
       source_url: "https://github.com/C-S-D/calcinator",
       start_permanent: Mix.env == :prod,
-      version: "1.6.0"
+      version: "1.7.0"
     ]
   end
 


### PR DESCRIPTION
# Changelog
## Enhancements
* Examples for how to `use Calcinator.Resources.Ecto.Repo` in `Calcinator.Resources.Ecto.Repo`'s `@moduledoc`

## Bug Fixes
* Add missing `ecto_schema_module/0` callback to `README` example of `use Calcinator.Resources.Ecto.Repo`.