### PR TITLE
Darkbushido feedback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,28 +3,57 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [Changelog](#changelog)
-  - [v1.6.0](#v160)
+  - [v2.0.0](#v200)
     - [Enhancements](#enhancements)
-  - [v1.5.1](#v151)
     - [Bug Fixes](#bug-fixes)
-  - [v1.5.0](#v150)
+    - [Incompatible Changes](#incompatible-changes)
+  - [v1.7.0](#v170)
     - [Enhancements](#enhancements-1)
     - [Bug Fixes](#bug-fixes-1)
-  - [v1.4.0](#v140)
+  - [v1.6.0](#v160)
     - [Enhancements](#enhancements-2)
-  - [v1.3.0](#v130)
-    - [Enhancements](#enhancements-3)
+  - [v1.5.1](#v151)
     - [Bug Fixes](#bug-fixes-2)
-  - [v1.2.0](#v120)
-    - [Enhancements](#enhancements-4)
+  - [v1.5.0](#v150)
+    - [Enhancements](#enhancements-3)
     - [Bug Fixes](#bug-fixes-3)
-  - [v1.1.0](#v110)
+  - [v1.4.0](#v140)
+    - [Enhancements](#enhancements-4)
+  - [v1.3.0](#v130)
     - [Enhancements](#enhancements-5)
     - [Bug Fixes](#bug-fixes-4)
+  - [v1.2.0](#v120)
+    - [Enhancements](#enhancements-6)
+    - [Bug Fixes](#bug-fixes-5)
+  - [v1.1.0](#v110)
+    - [Enhancements](#enhancements-7)
+    - [Bug Fixes](#bug-fixes-6)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 # Changelog
+
+## v2.0.0
+
+### Enhancements
+* [#10](https://github.com/C-S-D/calcinator/pull/10) - [@KronicDeth](https://github.com/KronicDeth)
+  * Explain why `relationships/2` is overridden in views
+  * Routing docs for `get_related_resource` and `show_relationship`
+  * Actions and related Authorization docs for `Calcinator.Controller`
+  * Use `Ecto.Repo` `config/0` instead of requiring `sandboxed?/0` to be defined.
+
+### Bug Fixes
+* [#10](https://github.com/C-S-D/calcinator/pull/10) - [@KronicDeth](https://github.com/KronicDeth)
+  * Add missing renames for README controllers
+    * `alias InterpreterServerWeb.Controller` -> `alias Calcinator.Controller`
+    * `use Controller.Resources,` -> `use Controller,`
+  * Replace `use MyApp.Web, :view` with `use JaSerializer.PhoenixView`, so it doesn't require `MyApp.Web.view/0` to include `use JaSerializer.PhoenixView`
+  * Renamed second `Author` `Ecto.Schema` modules to `Post`
+  * Don't require `user` assign in `Calcinator.Controller`
+  * Fix Elixir 1.4 `()` warnings.
+
+### Incompatible Changes
+* [#10](https://github.com/C-S-D/calcinator/pull/10) - Instead of requiring user assign in `Plug.Conn` to get `subject` for `%Calcinator{}`, a private key, `:calcinator_subject`, will be used using `Plug.Conn.put_private`.  The `subject` will be stored using `Calcinator.Controller.put_subject` and retrieved with `Calcinator.Controller.get_subject`.  Calling `put_subject` in a plug is shown in README and `Calcinator.Controller` examples. - [@KronicDeth](https://github.com/KronicDeth)
 
 ## v1.7.0
 

--- a/README.md
+++ b/README.md
@@ -214,9 +214,9 @@ defmodule MyAppWeb.PostController do
 
   use MyAppWeb.Web, :controller
 
-  alias InterpreterServerWeb.Controller
+  alias Calcinator.Controller
 
-  use Controller.Resources,
+  use Controller,
       actions: ~w(index show)a,
       configuration: %Calcinator{
         authorization_module: MyAppWeb.Authorization,
@@ -435,9 +435,9 @@ defmodule LocalAppWeb.PostController do
 
   use LocalAppWeb.Web, :controller
 
-  alias InterpreterServerWeb.Controller
+  alias Calcinator.Controller
 
-  use Controller.Resources,
+  use Controller,
       actions: ~w(index show)a,
       configuration: %Calcinator{
         authorization_module: LocalAppWeb.Authorization,

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ end
 -- `apps/my_app/lib/my_app/author.ex`
 
 ```elixir
-defmodule MyApp.Author do
+defmodule MyApp.Post do
   @moduledoc """
   Posts by a `MyApp.Author`.
   """
@@ -264,7 +264,7 @@ end
 -- `apps/remote_app/lib/remote_app/author.ex`
 
 ```elixir
-defmodule RemoteApp.Author do
+defmodule RemoteApp.Post do
   @moduledoc """
   Posts by a `RemoteApp.Author`.
   """

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ defmodule MyAppWeb.PostView do
 
   alias MyApp.Post
 
-  use MyAppWeb.Web, :view
+  use JaSerializer.PhoenixView
   use Calcinator.JaSerializer.PhoenixView,
       phoenix_view_module: __MODULE__
 
@@ -368,7 +368,7 @@ end
 
 ##### View Module
 
-`Calcinator` relies on `JaSerializer` to define view module
+`Calcinator` relies on `JaSerializer` to define view module.
 
 ```elixir
 defmodule LocalAppWeb.PostView do
@@ -378,7 +378,7 @@ defmodule LocalAppWeb.PostView do
 
   alias RemoteApp.Post
 
-  use LocalAppWeb.Web, :view
+  use JaSerializer.PhoenixView
   use Calcinator.JaSerializer.PhoenixView,
       phoenix_view_module: __MODULE__
 

--- a/README.md
+++ b/README.md
@@ -204,6 +204,10 @@ end
 ```
 --- `apps/my_app_web/lib/my_app_web/post_view.ex`
 
+The `relationships/2` override is counter to `JaSerializer`'s own recommendations.  It recommends doing a `Repo` call
+to load associations on demand, but that is against the Phoenix Core recommendations to make view modules side-effect
+free, so the `relationships/2` override excludes the relationship from including even linkage data when it's not loaded
+
 ##### Controller Module
 
 ```elixir
@@ -424,6 +428,10 @@ defmodule LocalAppWeb.PostView do
 end
 ```
 --- `apps/local_app_web/lib/local_app_web/post_view.ex`
+
+The `relationships/2` override is counter to `JaSerializer`'s own recommendations.  It recommends doing a `Repo` call
+to load associations on demand, but that is against the Phoenix Core recommendations to make view modules side-effect
+free, so the `relationships/2` override excludes the relationship from including even linkage data when it's not loaded
 
 ##### Controller Module
 

--- a/lib/calcinator.ex
+++ b/lib/calcinator.ex
@@ -6,6 +6,7 @@ defmodule Calcinator do
 
   alias Alembic.{Document, Fetch, Fetch.Includes, FromJson, ToParams, Source}
   alias Calcinator.{Authorization, Meta}
+  alias Calcinator.Authorization.Subjectless
   alias Calcinator.Resources.{Page, Sorts}
 
   # Constants
@@ -15,7 +16,7 @@ defmodule Calcinator do
   # Struct
 
   defstruct associations_by_include: %{},
-            authorization_module: nil,
+            authorization_module: Subjectless,
             ecto_schema_module: nil,
             params: %{},
             resources_module: nil,
@@ -47,7 +48,8 @@ defmodule Calcinator do
   @type rendered :: map
 
   @typedoc """
-    * `authorization_module` - The module that implements the `Calcinator.Authorization` behaviour
+    * `authorization_module` - The module that implements the `Calcinator.Authorization` behaviour.
+      Defaults to `Calcinator.Authorization.Subjectless`.
     * `subject` - the subject that is trying to do the action and needs to be authorized by `authorization_module`
     * `target` - the target of `subject`'s action
   """

--- a/lib/calcinator/controller.ex
+++ b/lib/calcinator/controller.ex
@@ -3,6 +3,62 @@ defmodule Calcinator.Controller do
   Controller that replicates [`JSONAPI::ActsAsResourceController`](http://www.rubydoc.info/gems/jsonapi-resources/
   JSONAPI/ActsAsResourceController).
 
+  ## Actions
+
+  The available actions:
+    * `create`
+    * `delete`
+    * `get_related_resource`
+    * `index`
+    * `show`
+    * `show_relationship`
+    * `update`
+
+  Chosen actions are specified to the `use Calcinator.Controller` call as a list of atoms:
+
+      use Calcinator.Controller,
+          actions: ~w(create delete get_related_resource index show show_relationship update)a,
+          ...
+
+  ## Authorization
+
+  ### Authenticated/Authorized Read/Write
+
+  If you authenticate users, you need to tell `Calcinator.Controller` they are your `subject` for the
+  `authorization_module`
+
+      alias Calcinator.Controller
+
+      use Controller,
+          actions: ~w(create delete get_related_resource index show show_relationship update)a,
+          configuration: %Controller{
+            authorization_module: MyApp.Authorization,
+            ...
+          }
+
+      # Plugs
+
+      plug :put_subject
+
+      # Functions
+
+      def put_subject(conn = %Conn{assigns: %{user: user}}, _), do: Controller.put_subject(conn, user)
+
+  ### Public Read-Only
+
+  If the controller exposes a read-only resource that you're comfortable being publicly-readable, you can skip
+  authorization: it will default to `Calcinator.Authorization.Subjectless`.  `Calcinator.Authorization.Subjectless` will
+  error out if you starts to have a non-`nil` `subject`, so it will catch if you're mixing authenticated and
+  unauthenticated pipelines accidentally.
+
+      alias Calcinator.Controller
+
+      use Controller,
+          actions: ~w(get_related_resource index show show_relationship)a,
+          configuration: %Controller{
+            ...
+          }
+
   ## Routing
 
   ### CRUD

--- a/lib/calcinator/meta/beam.ex
+++ b/lib/calcinator/meta/beam.ex
@@ -78,6 +78,6 @@ defmodule Calcinator.Meta.Beam do
 
   @spec version1_token(repo) :: version1_token
   def version1_token(repo) do
-    %{owner: self, repo: repo}
+    %{owner: self(), repo: repo}
   end
 end

--- a/lib/calcinator/resources/ecto/repo.ex
+++ b/lib/calcinator/resources/ecto/repo.ex
@@ -272,9 +272,7 @@ defmodule Calcinator.Resources.Ecto.Repo do
   @doc """
   Whether `module` `repo/0` is sandboxed and `allow_sandbox_access/1` should be called.
   """
-  def sandboxed?(module) do
-    module.repo().sandboxed?()
-  end
+  def sandboxed?(module), do: module.repo().config[:pool] == Ecto.Adapters.SQL.Sandbox
 
   @doc """
   Updates `struct` in `module` `repo/0` using `changeset`.

--- a/lib/calcinator/resources/ecto/repo.ex
+++ b/lib/calcinator/resources/ecto/repo.ex
@@ -155,7 +155,7 @@ defmodule Calcinator.Resources.Ecto.Repo do
   def allow_sandbox_access(%{owner: owner, repo: repo}) do
     repo
     |> List.wrap()
-    |> Enum.each(&Sandbox.allow(&1, owner, self))
+    |> Enum.each(&Sandbox.allow(&1, owner, self()))
   end
 
   @doc """

--- a/mix.exs
+++ b/mix.exs
@@ -18,7 +18,7 @@ defmodule Calcinator.Mixfile do
       ],
       source_url: "https://github.com/C-S-D/calcinator",
       start_permanent: Mix.env == :prod,
-      version: "1.7.0"
+      version: "2.0.0"
     ]
   end
 

--- a/test/calcinator/controller_test.exs
+++ b/test/calcinator/controller_test.exs
@@ -1,0 +1,5 @@
+defmodule Calcinator.ControllerTest do
+  use ExUnit.Case, async: true
+
+  doctest Calcinator.Controller
+end


### PR DESCRIPTION
@darkbushido, can you review that I didn't miss any problems we encountered on 2017-01-23?

# Changelog

## Enhancements
* Explain why `relationships/2` is overridden in views
* Routing docs for `get_related_resource` and `show_relationship`
* Actions and related Authorization docs for `Calcinator.Controller`
* Use `Ecto.Repo` `config/0` instead of requiring `sandboxed?/0` to be defined.

## Bug Fixes
* Add missing renames for README controllers
  * `alias InterpreterServerWeb.Controller` -> `alias Calcinator.Controller`
  * `use Controller.Resources,` -> `use Controller,`
* Replace `use MyApp.Web, :view` with `use JaSerializer.PhoenixView`, so it doesn't require `MyApp.Web.view/0` to include `use JaSerializer.PhoenixView`
* Renamed second `Author` `Ecto.Schema` modules to `Post`
* Don't require `user` assign in `Calcinator.Controller`
* Fix Elixir 1.4 `()` warnings.

## Incompatible Changes
* Instead of requiring user assign in `Plug.Conn` to get `subject` for `%Calcinator{}`, a private key, `:calcinator_subject`, will be used using `Plug.Conn.put_private`.  The `subject` will be stored using `Calcinator.Controller.put_subject` and retrieved with `Calcinator.Controller.get_subject`.  Calling `put_subject` in a plug is shown in README and `Calcinator.Controller` examples.