### PR TITLE
Wrap Controller.* in Code.ensure_loaded?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
   * Renamed second `Author` `Ecto.Schema` modules to `Post`
   * Don't require `user` assign in `Calcinator.Controller`
   * Fix Elixir 1.4 `()` warnings.
+* [#11](https://github.com/C-S-D/calcinator/pull/11) - `Code.ensure_loaded?(Phoenix.Controller)` can be used to protect `Calcinator.Controller.Error` and `Calcinator.Controller`, so that it is not defined when its dependency, `Phoenix.Controller` is not available.  Without this change, `(CompileError) lib/calcinator/controller/error.ex:12: module Phoenix.Controller is not loaded and could not be found` is raised in retort. - [@KronicDeth](https://github.com/KronicDeth)
 
 ### Incompatible Changes
 * [#10](https://github.com/C-S-D/calcinator/pull/10) - Instead of requiring user assign in `Plug.Conn` to get `subject` for `%Calcinator{}`, a private key, `:calcinator_subject`, will be used using `Plug.Conn.put_private`.  The `subject` will be stored using `Calcinator.Controller.put_subject` and retrieved with `Calcinator.Controller.get_subject`.  Calling `put_subject` in a plug is shown in README and `Calcinator.Controller` examples. - [@KronicDeth](https://github.com/KronicDeth)

--- a/lib/calcinator/controller.ex
+++ b/lib/calcinator/controller.ex
@@ -1,177 +1,40 @@
-defmodule Calcinator.Controller do
-  @moduledoc """
-  Controller that replicates [`JSONAPI::ActsAsResourceController`](http://www.rubydoc.info/gems/jsonapi-resources/
-  JSONAPI/ActsAsResourceController).
+if Code.ensure_loaded?(Phoenix.Controller) do
+  defmodule Calcinator.Controller do
+    @moduledoc """
+    Controller that replicates [`JSONAPI::ActsAsResourceController`](http://www.rubydoc.info/gems/jsonapi-resources/
+    JSONAPI/ActsAsResourceController).
 
-  ## Actions
+    ## Actions
 
-  The available actions:
-    * `create`
-    * `delete`
-    * `get_related_resource`
-    * `index`
-    * `show`
-    * `show_relationship`
-    * `update`
+    The available actions:
+      * `create`
+      * `delete`
+      * `get_related_resource`
+      * `index`
+      * `show`
+      * `show_relationship`
+      * `update`
 
-  Chosen actions are specified to the `use Calcinator.Controller` call as a list of atoms:
+    Chosen actions are specified to the `use Calcinator.Controller` call as a list of atoms:
 
-      use Calcinator.Controller,
-          actions: ~w(create delete get_related_resource index show show_relationship update)a,
-          ...
-
-  ## Authorization
-
-  ### Authenticated/Authorized Read/Write
-
-  If you authenticate users, you need to tell `Calcinator.Controller` they are your `subject` for the
-  `authorization_module`
-
-      alias Calcinator.Controller
-
-      use Controller,
-          actions: ~w(create delete get_related_resource index show show_relationship update)a,
-          configuration: %Controller{
-            authorization_module: MyApp.Authorization,
+        use Calcinator.Controller,
+            actions: ~w(create delete get_related_resource index show show_relationship update)a,
             ...
-          }
 
-      # Plugs
+    ## Authorization
 
-      plug :put_subject
+    ### Authenticated/Authorized Read/Write
 
-      # Functions
+    If you authenticate users, you need to tell `Calcinator.Controller` they are your `subject` for the
+    `authorization_module`
 
-      def put_subject(conn = %Conn{assigns: %{user: user}}, _), do: Controller.put_subject(conn, user)
-
-  ### Public Read-Only
-
-  If the controller exposes a read-only resource that you're comfortable being publicly-readable, you can skip
-  authorization: it will default to `Calcinator.Authorization.Subjectless`.  `Calcinator.Authorization.Subjectless` will
-  error out if you starts to have a non-`nil` `subject`, so it will catch if you're mixing authenticated and
-  unauthenticated pipelines accidentally.
-
-      alias Calcinator.Controller
-
-      use Controller,
-          actions: ~w(get_related_resource index show show_relationship)a,
-          configuration: %Controller{
-            ...
-          }
-
-  ## Routing
-
-  ### CRUD
-
-  If you only the standard CRUD actions
-
-      use Calcinator.Controller,
-          actions: ~w(create delete index show update)a,
-          ...
-
-  then the normal Phoenix `resources` macro will work
-
-     resources "/posts", PostController
-
-  ### `get_related_resource/3` and `show_relationship/3`
-
-  If you use the `get_related_resource/3` or `show_relationship/3` actions
-
-      use Calcinator.Controller,
-          actions: ~w(get_related_resource index show show_relationship),
-          ...
-
-  You'll need custom routes
-
-      resources "/posts", PostController do
-         get "/author",
-             PostController,
-             :get_related_resource,
-             as: :author,
-             assigns: %{
-               related: %{
-                 view_module: AuthorView
-               },
-               source: %{
-                 association: :credential_source,
-                 id_key: "credential_id"
-               }
-             }
-         get "/relationships/author"",
-            PostController,
-            :show_relationship,
-            as: :relationships_author,
-            assigns: %{
-              association: :author,
-              source: %{
-                id_key: "author_id"
-              }
-            }
-      end
-
-  """
-
-  alias Alembic.Document
-  alias Plug.Conn
-
-  import Calcinator.{Authorization, Controller.Error}
-  import Conn
-
-  # Macros
-
-  defmacro __using__(opts) do
-    {names, _} = opts
-                 |> Keyword.fetch!(:actions)
-                 |> Code.eval_quoted([], __CALLER__)
-    quoted_configuration = Keyword.fetch!(opts, :configuration)
-
-    for name <- names do
-      name_quoted_action = quoted_action(name, quoted_configuration)
-      Module.eval_quoted __CALLER__.module, name_quoted_action, [], __CALLER__
-    end
-  end
-
-  # Functions
-
-  @doc """
-  Gets the subject used for the `%Calcinator{}` passed to action functions.
-
-      iex> %Plug.Conn{} |>
-      iex> Calcinator.Controller.put_subject(:admin) |>
-      iex> Calcinator.Controller.get_subject()
-      :admin
-
-  It can be `nil` if `put_subject/2` was not called or called `put_subject(conn, nil)`.
-
-      iex> Calcinator.Controller.get_subject(%Plug.Conn{})
-      nil
-      iex> %Plug.Conn{} |>
-      iex> Calcinator.Controller.put_subject(nil) |>
-      iex> Calcinator.Controller.get_subject()
-      nil
-
-  """
-  @spec get_subject(Conn.t) :: Authorization.subject
-  def get_subject(conn), do: conn.private[:calcinator_subject]
-
-  @doc """
-  Puts the subject used for the `%Calciantor{}` pass to action functions.
-
-  If you use subject-based authorization, where you don't use `Calcinator.Authorization.Subjectless` (the default) for
-  the `:authorization` module, then you will need to set the subject.
-
-  Here, the subject is set from the `user` assign set by some authorization plug (not shown)
-
-      defmodule MyAppWeb.PostController do
         alias Calcinator.Controller
 
         use Controller,
-            actions: ~w(create destroy index show update)a,
-            configuration: %Calcinator{
-              authorization_module: MyAppWeb.Authorization,
-              ecto_schema_module: MyApp.Post,
-              resources_module: MyApp.Posts,
-              view_module: MyAppWeb.PostView
+            actions: ~w(create delete get_related_resource index show show_relationship update)a,
+            configuration: %Controller{
+              authorization_module: MyApp.Authorization,
+              ...
             }
 
         # Plugs
@@ -181,204 +44,347 @@ defmodule Calcinator.Controller do
         # Functions
 
         def put_subject(conn = %Conn{assigns: %{user: user}}, _), do: Controller.put_subject(conn, user)
-      end
 
-  """
-  @spec put_subject(Conn.t, Authorization.subject) :: Conn.t
-  def put_subject(conn, subject), do: put_private(conn, :calcinator_subject, subject)
+    ### Public Read-Only
 
-  ## Action Functions
+    If the controller exposes a read-only resource that you're comfortable being publicly-readable, you can skip
+    authorization: it will default to `Calcinator.Authorization.Subjectless`.  `Calcinator.Authorization.Subjectless`
+    will error out if you starts to have a non-`nil` `subject`, so it will catch if you're mixing authenticated and
+    unauthenticated pipelines accidentally.
 
-  @spec create(Conn.t, Calcinator.params, Calcinator.t) :: Conn.t
-  def create(conn = %Conn{}, params, calcinator = %Calcinator{}) do
-    case Calcinator.create(%Calcinator{calcinator | subject: get_subject(conn)}, params) do
-      {:ok, rendered} ->
-        conn
-        |> put_status(:created)
-        |> put_resp_content_type("application/vnd.api+json")
-        |> send_resp(:created, Poison.encode!(rendered))
-      {:error, :unauthorized} ->
-        forbidden(conn)
-      {:error, changeset = %Ecto.Changeset{}} ->
-        render_changeset_error(conn, changeset)
-      {:error, document = %Document{}} ->
-        render_json(conn, document, :unprocessable_entity)
-    end
-  end
+        alias Calcinator.Controller
 
-  @spec delete(Conn.t, Calcinator.params, Calcinator.t) :: Conn.t
-  def delete(conn, params = %{"id" => _}, calcinator = %Calcinator{}) do
-    case Calcinator.delete(%Calcinator{calcinator | subject: get_subject(conn)}, params) do
-      :ok ->
-        conn
-        |> put_resp_content_type("application/vnd.api+json")
-        |> send_resp(:no_content, "")
-      {:error, {:not_found, parameter}} ->
-        not_found(conn, parameter)
-      {:error, :unauthorized} ->
-        forbidden(conn)
-    end
-  end
-
-  @doc """
-  Unlike `show`, which can infer its information from the default routing information provided by Phoenix's `resources`
-  routing macro, `get_related_resource/3` requires manual routing to setup the `related` and `source` assigns.
-
-      resources "/posts", PostController do
-         get "/author",
-             PostController,
-             :get_related_resource,
-             as: :author,
-             assigns: %{
-               related: %{
-                 view_module: AuthorView
-               },
-               source: %{
-                 association: :credential_source,
-                 id_key: "credential_id"
-               }
-             }
-      end
-
-  """
-  @spec get_related_resource(Conn.t, Calcinator.params, Calcinator.t) :: Conn.t
-  def get_related_resource(
-        conn = %Conn{
-          assigns: %{
-            related: related,
-            source: source
-          }
-        },
-        params,
-        calcinator = %Calcinator{}
-      ) do
-    case Calcinator.get_related_resource(
-           %Calcinator{calcinator | subject: get_subject(conn)},
-           params,
-           %{
-             related: related,
-             source: source
-           }
-         ) do
-      {:ok, rendered} ->
-        conn
-        |> put_status(:ok)
-        |> put_resp_content_type("application/vnd.api+json")
-        |> send_resp(:ok, Poison.encode!(rendered))
-      {:error, {:not_found, parameter}} ->
-        not_found(conn, parameter)
-      {:error, :unauthorized} ->
-        forbidden(conn)
-    end
-  end
-
-  @spec index(Conn.t, Calcinator.params, Calcinator.t) :: Conn.t
-  def index(conn, params, calcinator = %Calcinator{}) do
-    case Calcinator.index(%Calcinator{calcinator | subject: get_subject(conn)}, params, %{base_uri: base_uri(conn)}) do
-      {:ok, rendered} ->
-        conn
-        |> put_status(:ok)
-        |> put_resp_content_type("application/vnd.api+json")
-        |> send_resp(:ok, Poison.encode!(rendered))
-      {:error, :unauthorized} ->
-        forbidden(conn)
-      {:error, document = %Document{}} ->
-         render_json(conn, document, :unprocessable_entity)
-    end
-  end
-
-  @spec show(Conn.t, Calcinator.params, Calcinator.t) :: Conn.t
-  def show(conn, params = %{"id" => _}, calcinator = %Calcinator{}) do
-     case Calcinator.show(%Calcinator{calcinator | subject: get_subject(conn)}, params) do
-       {:ok, rendered} ->
-         conn
-         |> put_status(:ok)
-         |> put_resp_content_type("application/vnd.api+json")
-         |> send_resp(:ok, Poison.encode!(rendered))
-       {:error, {:not_found, parameter}} ->
-         not_found(conn, parameter)
-       {:error, :unauthorized} ->
-         forbidden(conn)
-       {:error, document = %Document{}} ->
-         render_json(conn, document, :unprocessable_entity)
-     end
-  end
-
-  @doc """
-  Unlike `show`, which can infer its information from the default routing information provided by Phoenix's `resources`
-  routing macro, `show_relationship/3` requires manual routing to setup the `association` and `source` assigns.
-
-      resources "/posts", PostController do
-        get "/relationships/author"",
-            PostController,
-            :show_relationship,
-            as: :relationships_author,
-            assigns: %{
-              association: :author,
-              source: %{
-                id_key: "author_id"
-              }
+        use Controller,
+            actions: ~w(get_related_resource index show show_relationship)a,
+            configuration: %Controller{
+              ...
             }
+
+    ## Routing
+
+    ### CRUD
+
+    If you only the standard CRUD actions
+
+        use Calcinator.Controller,
+            actions: ~w(create delete index show update)a,
+            ...
+
+    then the normal Phoenix `resources` macro will work
+
+       resources "/posts", PostController
+
+    ### `get_related_resource/3` and `show_relationship/3`
+
+    If you use the `get_related_resource/3` or `show_relationship/3` actions
+
+        use Calcinator.Controller,
+            actions: ~w(get_related_resource index show show_relationship),
+            ...
+
+    You'll need custom routes
+
+        resources "/posts", PostController do
+           get "/author",
+               PostController,
+               :get_related_resource,
+               as: :author,
+               assigns: %{
+                 related: %{
+                   view_module: AuthorView
+                 },
+                 source: %{
+                   association: :credential_source,
+                   id_key: "credential_id"
+                 }
+               }
+           get "/relationships/author"",
+              PostController,
+              :show_relationship,
+              as: :relationships_author,
+              assigns: %{
+                association: :author,
+                source: %{
+                  id_key: "author_id"
+                }
+              }
+        end
+
+    """
+
+    alias Alembic.Document
+    alias Plug.Conn
+
+    import Calcinator.{Authorization, Controller.Error}
+    import Conn
+
+    # Macros
+
+    defmacro __using__(opts) do
+      {names, _} = opts
+                   |> Keyword.fetch!(:actions)
+                   |> Code.eval_quoted([], __CALLER__)
+      quoted_configuration = Keyword.fetch!(opts, :configuration)
+
+      for name <- names do
+        name_quoted_action = quoted_action(name, quoted_configuration)
+        Module.eval_quoted __CALLER__.module, name_quoted_action, [], __CALLER__
       end
-
-  """
-  @spec show_relationship(Conn.t, Calcinator.params, Calcinator.t) :: Conn.t
-  def show_relationship(
-        conn = %Conn{
-          assigns: %{
-            related: related,
-            source: source
-          }
-        },
-        params,
-        calcinator = %Calcinator{}
-      ) do
-    case Calcinator.show_relationship(
-           %Calcinator{calcinator | subject: get_subject(conn)},
-           params,
-           %{related: related, source: source}
-         ) do
-      {:ok, rendered} ->
-        conn
-        |> put_status(:ok)
-        |> put_resp_content_type("application/vnd.api+json")
-        |> send_resp(:ok, Poison.encode!(rendered))
-      {:error, {:not_found, parameter}} ->
-        not_found(conn, parameter)
-      {:error, :unauthorized} ->
-        forbidden(conn)
     end
-  end
 
-  @spec update(Conn.t, Calcinator.params, Calcinator.t) :: Conn.t
-  def update(conn, params, calcinator = %Calcinator{}) do
-     case Calcinator.update(%Calcinator{calcinator | subject: get_subject(conn)}, params) do
-       {:ok, rendered} ->
-         conn
-         |> put_status(:ok)
-         |> put_resp_content_type("application/vnd.api+json")
-         |> send_resp(:ok, Poison.encode!(rendered))
-       {:error, :bad_gateway} ->
-         bad_gateway(conn)
-       {:error, {:not_found, parameter}} ->
-         not_found(conn, parameter)
-       {:error, :unauthorized} ->
-         forbidden(conn)
-       {:error, changeset = %Ecto.Changeset{}} ->
-         render_changeset_error(conn, changeset)
-       {:error, document = %Document{}} ->
-         render_json(conn, document, :unprocessable_entity)
-     end
-  end
+    # Functions
 
-  ## Private Functions
+    @doc """
+    Gets the subject used for the `%Calcinator{}` passed to action functions.
 
-  defp base_uri(%Conn{request_path: path}), do: %URI{path: path}
+        iex> %Plug.Conn{} |>
+        iex> Calcinator.Controller.put_subject(:admin) |>
+        iex> Calcinator.Controller.get_subject()
+        :admin
 
-  defp quoted_action(quoted_name, quoted_configuration) do
-    quote do
-      def unquote(quoted_name)(conn, params) do
-        Calcinator.Controller.unquote(quoted_name)(conn, params, unquote(quoted_configuration))
+    It can be `nil` if `put_subject/2` was not called or called `put_subject(conn, nil)`.
+
+        iex> Calcinator.Controller.get_subject(%Plug.Conn{})
+        nil
+        iex> %Plug.Conn{} |>
+        iex> Calcinator.Controller.put_subject(nil) |>
+        iex> Calcinator.Controller.get_subject()
+        nil
+
+    """
+    @spec get_subject(Conn.t) :: Authorization.subject
+    def get_subject(conn), do: conn.private[:calcinator_subject]
+
+    @doc """
+    Puts the subject used for the `%Calciantor{}` pass to action functions.
+
+    If you use subject-based authorization, where you don't use `Calcinator.Authorization.Subjectless` (the default) for
+    the `:authorization` module, then you will need to set the subject.
+
+    Here, the subject is set from the `user` assign set by some authorization plug (not shown)
+
+        defmodule MyAppWeb.PostController do
+          alias Calcinator.Controller
+
+          use Controller,
+              actions: ~w(create destroy index show update)a,
+              configuration: %Calcinator{
+                authorization_module: MyAppWeb.Authorization,
+                ecto_schema_module: MyApp.Post,
+                resources_module: MyApp.Posts,
+                view_module: MyAppWeb.PostView
+              }
+
+          # Plugs
+
+          plug :put_subject
+
+          # Functions
+
+          def put_subject(conn = %Conn{assigns: %{user: user}}, _), do: Controller.put_subject(conn, user)
+        end
+
+    """
+    @spec put_subject(Conn.t, Authorization.subject) :: Conn.t
+    def put_subject(conn, subject), do: put_private(conn, :calcinator_subject, subject)
+
+    ## Action Functions
+
+    @spec create(Conn.t, Calcinator.params, Calcinator.t) :: Conn.t
+    def create(conn = %Conn{}, params, calcinator = %Calcinator{}) do
+      case Calcinator.create(%Calcinator{calcinator | subject: get_subject(conn)}, params) do
+        {:ok, rendered} ->
+          conn
+          |> put_status(:created)
+          |> put_resp_content_type("application/vnd.api+json")
+          |> send_resp(:created, Poison.encode!(rendered))
+        {:error, :unauthorized} ->
+          forbidden(conn)
+        {:error, changeset = %Ecto.Changeset{}} ->
+          render_changeset_error(conn, changeset)
+        {:error, document = %Document{}} ->
+          render_json(conn, document, :unprocessable_entity)
+      end
+    end
+
+    @spec delete(Conn.t, Calcinator.params, Calcinator.t) :: Conn.t
+    def delete(conn, params = %{"id" => _}, calcinator = %Calcinator{}) do
+      case Calcinator.delete(%Calcinator{calcinator | subject: get_subject(conn)}, params) do
+        :ok ->
+          conn
+          |> put_resp_content_type("application/vnd.api+json")
+          |> send_resp(:no_content, "")
+        {:error, {:not_found, parameter}} ->
+          not_found(conn, parameter)
+        {:error, :unauthorized} ->
+          forbidden(conn)
+      end
+    end
+
+    @doc """
+    Unlike `show`, which can infer its information from the default routing information provided by Phoenix's
+    `resources` routing macro, `get_related_resource/3` requires manual routing to setup the `related` and `source`
+    assigns.
+
+        resources "/posts", PostController do
+           get "/author",
+               PostController,
+               :get_related_resource,
+               as: :author,
+               assigns: %{
+                 related: %{
+                   view_module: AuthorView
+                 },
+                 source: %{
+                   association: :credential_source,
+                   id_key: "credential_id"
+                 }
+               }
+        end
+
+    """
+    @spec get_related_resource(Conn.t, Calcinator.params, Calcinator.t) :: Conn.t
+    def get_related_resource(
+          conn = %Conn{
+            assigns: %{
+              related: related,
+              source: source
+            }
+          },
+          params,
+          calcinator = %Calcinator{}
+        ) do
+      case Calcinator.get_related_resource(
+             %Calcinator{calcinator | subject: get_subject(conn)},
+             params,
+             %{
+               related: related,
+               source: source
+             }
+           ) do
+        {:ok, rendered} ->
+          conn
+          |> put_status(:ok)
+          |> put_resp_content_type("application/vnd.api+json")
+          |> send_resp(:ok, Poison.encode!(rendered))
+        {:error, {:not_found, parameter}} ->
+          not_found(conn, parameter)
+        {:error, :unauthorized} ->
+          forbidden(conn)
+      end
+    end
+
+    @spec index(Conn.t, Calcinator.params, Calcinator.t) :: Conn.t
+    def index(conn, params, calcinator = %Calcinator{}) do
+      case Calcinator.index(%Calcinator{calcinator | subject: get_subject(conn)},
+                            params,
+                            %{base_uri: base_uri(conn)}) do
+        {:ok, rendered} ->
+          conn
+          |> put_status(:ok)
+          |> put_resp_content_type("application/vnd.api+json")
+          |> send_resp(:ok, Poison.encode!(rendered))
+        {:error, :unauthorized} ->
+          forbidden(conn)
+        {:error, document = %Document{}} ->
+           render_json(conn, document, :unprocessable_entity)
+      end
+    end
+
+    @spec show(Conn.t, Calcinator.params, Calcinator.t) :: Conn.t
+    def show(conn, params = %{"id" => _}, calcinator = %Calcinator{}) do
+       case Calcinator.show(%Calcinator{calcinator | subject: get_subject(conn)}, params) do
+         {:ok, rendered} ->
+           conn
+           |> put_status(:ok)
+           |> put_resp_content_type("application/vnd.api+json")
+           |> send_resp(:ok, Poison.encode!(rendered))
+         {:error, {:not_found, parameter}} ->
+           not_found(conn, parameter)
+         {:error, :unauthorized} ->
+           forbidden(conn)
+         {:error, document = %Document{}} ->
+           render_json(conn, document, :unprocessable_entity)
+       end
+    end
+
+    @doc """
+    Unlike `show`, which can infer its information from the default routing information provided by Phoenix's
+    `resources` routing macro, `show_relationship/3` requires manual routing to setup the `association` and `source`
+    assigns.
+
+        resources "/posts", PostController do
+          get "/relationships/author"",
+              PostController,
+              :show_relationship,
+              as: :relationships_author,
+              assigns: %{
+                association: :author,
+                source: %{
+                  id_key: "author_id"
+                }
+              }
+        end
+
+    """
+    @spec show_relationship(Conn.t, Calcinator.params, Calcinator.t) :: Conn.t
+    def show_relationship(
+          conn = %Conn{
+            assigns: %{
+              related: related,
+              source: source
+            }
+          },
+          params,
+          calcinator = %Calcinator{}
+        ) do
+      case Calcinator.show_relationship(
+             %Calcinator{calcinator | subject: get_subject(conn)},
+             params,
+             %{related: related, source: source}
+           ) do
+        {:ok, rendered} ->
+          conn
+          |> put_status(:ok)
+          |> put_resp_content_type("application/vnd.api+json")
+          |> send_resp(:ok, Poison.encode!(rendered))
+        {:error, {:not_found, parameter}} ->
+          not_found(conn, parameter)
+        {:error, :unauthorized} ->
+          forbidden(conn)
+      end
+    end
+
+    @spec update(Conn.t, Calcinator.params, Calcinator.t) :: Conn.t
+    def update(conn, params, calcinator = %Calcinator{}) do
+       case Calcinator.update(%Calcinator{calcinator | subject: get_subject(conn)}, params) do
+         {:ok, rendered} ->
+           conn
+           |> put_status(:ok)
+           |> put_resp_content_type("application/vnd.api+json")
+           |> send_resp(:ok, Poison.encode!(rendered))
+         {:error, :bad_gateway} ->
+           bad_gateway(conn)
+         {:error, {:not_found, parameter}} ->
+           not_found(conn, parameter)
+         {:error, :unauthorized} ->
+           forbidden(conn)
+         {:error, changeset = %Ecto.Changeset{}} ->
+           render_changeset_error(conn, changeset)
+         {:error, document = %Document{}} ->
+           render_json(conn, document, :unprocessable_entity)
+       end
+    end
+
+    ## Private Functions
+
+    defp base_uri(%Conn{request_path: path}), do: %URI{path: path}
+
+    defp quoted_action(quoted_name, quoted_configuration) do
+      quote do
+        def unquote(quoted_name)(conn, params) do
+          Calcinator.Controller.unquote(quoted_name)(conn, params, unquote(quoted_configuration))
+        end
       end
     end
   end

--- a/lib/calcinator/controller/error.ex
+++ b/lib/calcinator/controller/error.ex
@@ -1,103 +1,105 @@
-defmodule Calcinator.Controller.Error do
-  @moduledoc """
-  Errors returned by `Calcinator.Controller`.  Public, so that other controllers not using `Calcinator.Controller` can
-  have same format for errors.
-  """
+if Code.ensure_loaded?(Phoenix.Controller) do
+  defmodule Calcinator.Controller.Error do
+    @moduledoc """
+    Errors returned by `Calcinator.Controller`.  Public, so that other controllers not using `Calcinator.Controller` can
+    have same format for errors.
+    """
 
-  alias Alembic.{Document, Error, Source}
-  alias Calcinator.ChangesetView
-  alias Plug.Conn
+    alias Alembic.{Document, Error, Source}
+    alias Calcinator.ChangesetView
+    alias Plug.Conn
 
-  import Conn, only: [halt: 1, put_resp_content_type: 2, put_status: 2]
-  import Phoenix.Controller, only: [json: 2, render: 4]
+    import Conn, only: [halt: 1, put_resp_content_type: 2, put_status: 2]
+    import Phoenix.Controller, only: [json: 2, render: 4]
 
-  @doc """
-  Retort returned a 500 JSONAPI error inside a 422 JSONRPC error.
-  """
-  @spec bad_gateway(Conn.t) :: Conn.t
-  def bad_gateway(conn) do
-    conn
-    |> put_status(:bad_gateway)
-    |> put_resp_content_type("application/vnd.api+json")
-    |> json(
-         %Document{
-           errors: [
-             %Error{
-               status: "502",
-               title: "Bad Gateway"
-             }
-           ]
-         }
-       )
-  end
+    @doc """
+    Retort returned a 500 JSONAPI error inside a 422 JSONRPC error.
+    """
+    @spec bad_gateway(Conn.t) :: Conn.t
+    def bad_gateway(conn) do
+      conn
+      |> put_status(:bad_gateway)
+      |> put_resp_content_type("application/vnd.api+json")
+      |> json(
+           %Document{
+             errors: [
+               %Error{
+                 status: "502",
+                 title: "Bad Gateway"
+               }
+             ]
+           }
+         )
+    end
 
-  @doc """
-  The current resource or action is forbidden to the authenticated user
-  """
-  @spec forbidden(Conn.t) :: Conn.t
-  def forbidden(conn) do
-    conn
-    |> put_status(:forbidden)
-    |> put_resp_content_type("application/vnd.api+json")
-    |> json(
-         %Document{
-           errors: [
-             %Error{
-               detail: "You do not have permission for this resource.",
-               status: "403",
-               title: "Forbidden"
-             }
-           ]
-         }
-       )
-    |> halt()
-  end
+    @doc """
+    The current resource or action is forbidden to the authenticated user
+    """
+    @spec forbidden(Conn.t) :: Conn.t
+    def forbidden(conn) do
+      conn
+      |> put_status(:forbidden)
+      |> put_resp_content_type("application/vnd.api+json")
+      |> json(
+           %Document{
+             errors: [
+               %Error{
+                 detail: "You do not have permission for this resource.",
+                 status: "403",
+                 title: "Forbidden"
+               }
+             ]
+           }
+         )
+      |> halt()
+    end
 
-  @doc """
-  Puts 404 Resource Not Found JSONAPI error in `conn` with `parameter` as the source parameter.
-  """
-  @spec not_found(Conn.t, String.t) :: Conn.t
-  def not_found(conn, parameter) do
-    conn
-    |> put_status(:not_found)
-    |> put_resp_content_type("application/vnd.api+json")
-    |> json(
-         %Document{
-           errors: [
-             %Error{
-               source: %Source{
-                 parameter: parameter
-               },
-               status: "404",
-               title: "Resource Not Found"
-             }
-           ]
-         }
-       )
-    |> halt()
-  end
+    @doc """
+    Puts 404 Resource Not Found JSONAPI error in `conn` with `parameter` as the source parameter.
+    """
+    @spec not_found(Conn.t, String.t) :: Conn.t
+    def not_found(conn, parameter) do
+      conn
+      |> put_status(:not_found)
+      |> put_resp_content_type("application/vnd.api+json")
+      |> json(
+           %Document{
+             errors: [
+               %Error{
+                 source: %Source{
+                   parameter: parameter
+                 },
+                 status: "404",
+                 title: "Resource Not Found"
+               }
+             ]
+           }
+         )
+      |> halt()
+    end
 
-  @doc """
-  Renders `changeset` as an error object using the `Calcinator.ChangesetView`.
-  """
-  @spec render_changeset_error(Conn.t, Ecto.Changeset.t) :: Conn.t
-  def render_changeset_error(conn, changeset) do
-    conn
-    |> put_status(:unprocessable_entity)
-    |> put_resp_content_type("application/vnd.api+json")
-    |> render(ChangesetView, "error-object.json", changeset)
-    |> halt()
-  end
+    @doc """
+    Renders `changeset` as an error object using the `Calcinator.ChangesetView`.
+    """
+    @spec render_changeset_error(Conn.t, Ecto.Changeset.t) :: Conn.t
+    def render_changeset_error(conn, changeset) do
+      conn
+      |> put_status(:unprocessable_entity)
+      |> put_resp_content_type("application/vnd.api+json")
+      |> render(ChangesetView, "error-object.json", changeset)
+      |> halt()
+    end
 
-  @doc """
-  Renders `encodable` as JSON after `put_jsonapi_and_status` on the `conn`.
-  """
-  @spec render_json(Conn.t, term, atom) :: Conn.t
-  def render_json(conn, encodable, status) do
-    conn
-    |> put_status(status)
-    |> put_resp_content_type("application/vnd.api+json")
-    |> json(encodable)
-    |> halt()
+    @doc """
+    Renders `encodable` as JSON after `put_jsonapi_and_status` on the `conn`.
+    """
+    @spec render_json(Conn.t, term, atom) :: Conn.t
+    def render_json(conn, encodable, status) do
+      conn
+      |> put_status(status)
+      |> put_resp_content_type("application/vnd.api+json")
+      |> json(encodable)
+      |> halt()
+    end
   end
 end


### PR DESCRIPTION
# Changelog
## Bug Fixes
* `Code.ensure_loaded?(Phoenix.Controller)` can be used to protect `Calcinator.Controller.Error` and `Calcinator.Controller`, so that it is not defined when its dependency, `Phoenix.Controller` is not available.  Without this change, `(CompileError) lib/calcinator/controller/error.ex:12: module Phoenix.Controller is not loaded and could not be found` is raised in retort.