### PR TITLE
Fix capitalization of SubjectLess in Calcinator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,35 +3,46 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [Changelog](#changelog)
-  - [v2.0.0](#v200)
+  - [v2.1.0](#v210)
     - [Enhancements](#enhancements)
     - [Bug Fixes](#bug-fixes)
-    - [Incompatible Changes](#incompatible-changes)
-  - [v1.7.0](#v170)
+  - [v2.0.0](#v200)
     - [Enhancements](#enhancements-1)
     - [Bug Fixes](#bug-fixes-1)
-  - [v1.6.0](#v160)
+    - [Incompatible Changes](#incompatible-changes)
+  - [v1.7.0](#v170)
     - [Enhancements](#enhancements-2)
-  - [v1.5.1](#v151)
     - [Bug Fixes](#bug-fixes-2)
-  - [v1.5.0](#v150)
+  - [v1.6.0](#v160)
     - [Enhancements](#enhancements-3)
+  - [v1.5.1](#v151)
     - [Bug Fixes](#bug-fixes-3)
-  - [v1.4.0](#v140)
+  - [v1.5.0](#v150)
     - [Enhancements](#enhancements-4)
-  - [v1.3.0](#v130)
-    - [Enhancements](#enhancements-5)
     - [Bug Fixes](#bug-fixes-4)
-  - [v1.2.0](#v120)
+  - [v1.4.0](#v140)
+    - [Enhancements](#enhancements-5)
+  - [v1.3.0](#v130)
     - [Enhancements](#enhancements-6)
     - [Bug Fixes](#bug-fixes-5)
-  - [v1.1.0](#v110)
+  - [v1.2.0](#v120)
     - [Enhancements](#enhancements-7)
     - [Bug Fixes](#bug-fixes-6)
+  - [v1.1.0](#v110)
+    - [Enhancements](#enhancements-8)
+    - [Bug Fixes](#bug-fixes-7)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 # Changelog
+
+## v2.1.0
+
+### Enhancements
+* [#12](https://github.com/C-S-D/calcinator/pull/12) - Regression tests that `%Calcinator{}` default `authorization_module` implements `Calcinator.Authorization` behaviour. - [@KronicDeth](https://github.com/KronicDeth)
+
+### Bug Fixes
+* [#12](https://github.com/C-S-D/calcinator/pull/12) - Fix capitalization of `SubjectLess` when used as the `%Calcinator{}` default `authorization_module`. - [@KronicDeth](https://github.com/KronicDeth)
 
 ## v2.0.0
 

--- a/lib/calcinator.ex
+++ b/lib/calcinator.ex
@@ -6,7 +6,7 @@ defmodule Calcinator do
 
   alias Alembic.{Document, Fetch, Fetch.Includes, FromJson, ToParams, Source}
   alias Calcinator.{Authorization, Meta}
-  alias Calcinator.Authorization.Subjectless
+  alias Calcinator.Authorization.SubjectLess
   alias Calcinator.Resources.{Page, Sorts}
 
   # Constants
@@ -16,7 +16,7 @@ defmodule Calcinator do
   # Struct
 
   defstruct associations_by_include: %{},
-            authorization_module: Subjectless,
+            authorization_module: SubjectLess,
             ecto_schema_module: nil,
             params: %{},
             resources_module: nil,

--- a/mix.exs
+++ b/mix.exs
@@ -18,7 +18,7 @@ defmodule Calcinator.Mixfile do
       ],
       source_url: "https://github.com/C-S-D/calcinator",
       start_permanent: Mix.env == :prod,
-      version: "2.0.0"
+      version: "2.1.0"
     ]
   end
 

--- a/test/calcinator_test.exs
+++ b/test/calcinator_test.exs
@@ -1,8 +1,62 @@
 defmodule CalcinatorTest do
-  use ExUnit.Case
+  alias Calcinator.Resources.{TestAuthor, TestPost}
+
+  use ExUnit.Case, async: true
+
+  # Tests
+
   doctest Calcinator
 
-  test "the truth" do
-    assert 1 + 1 == 2
+  describe "Default authorization_module" do
+    setup :default_authorization_module
+
+    test "can?(subject, :create, module)",
+         %{default_authorization_module: default_authorization_module, subject: subject} do
+      assert default_authorization_module.can?(subject, :create, TestAuthor)
+    end
+
+    test "can?(subject, :create, Ecto.Changeset.t)",
+         %{default_authorization_module: default_authorization_module, subject: subject} do
+      changeset = TestAuthor.changeset(
+        %TestAuthor{},
+        %{name: "Alice", password: "password", password_confirmation: "password"}
+      )
+
+      assert default_authorization_module.can?(subject, :create, changeset)
+    end
+
+    test "can?(subject, :delete, struct)",
+         %{default_authorization_module: default_authorization_module, subject: subject} do
+      assert default_authorization_module.can?(subject, :delete, %TestAuthor{id: 1})
+    end
+
+    test "can?(subject, :index, module)",
+         %{default_authorization_module: default_authorization_module, subject: subject} do
+      assert default_authorization_module.can?(subject, :index, TestAuthor)
+    end
+
+    test "can?(subject, :show, struct)",
+         %{default_authorization_module: default_authorization_module, subject: subject} do
+      assert default_authorization_module.can?(subject, :show, %TestAuthor{})
+    end
+
+    test "can?(subject, :show, association_ascent)",
+         %{default_authorization_module: default_authorization_module, subject: subject} do
+      post = %TestPost{id: 2}
+      author = %TestAuthor{id: 1, posts: [post]}
+
+      assert default_authorization_module.can?(subject, :show, [post, author])
+    end
+
+    test "can?(subject, :update, struct)",
+         %{default_authorization_module: default_authorization_module, subject: subject} do
+      assert default_authorization_module.can?(subject, :update, %TestAuthor{})
+    end
+  end
+
+  # Functions
+
+  defp default_authorization_module(_) do
+    {:ok, %{default_authorization_module: Calcinator.__struct__.authorization_module, subject: nil}}
   end
 end

--- a/test/support/calcinator/resources/test_author.ex
+++ b/test/support/calcinator/resources/test_author.ex
@@ -5,6 +5,8 @@ defmodule Calcinator.Resources.TestAuthor do
 
   use Ecto.Schema
 
+  import Ecto.Changeset, only: [cast: 3]
+
   schema "authors" do
     field :name, :string
     field :password, :string, virtual: true
@@ -12,4 +14,8 @@ defmodule Calcinator.Resources.TestAuthor do
 
     has_many :posts, Calcinator.Resources.TestPost, foreign_key: :author_id
   end
+
+  # Functions
+
+  def changeset(model, params), do: cast(model, params, ~w(name password password_confirmation)a)
 end


### PR DESCRIPTION
# Changelog

## Enhancements
* Regression tests that `%Calcinator{}` default `authorization_module` implements `Calcinator.Authorization` behaviour

## Bug Fixes
* Fix capalization of `SubjectLess` when used as the `%Calcinator{}` default `authorization_module`.