### PR TITLE
VPP-2241: Filters should be a map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,16 @@
 
 # Changelog
 
+## v2.3.1
+
+### Bug Fixes
+* [#17](https://github.com/C-S-D/calcinator/pull/17) - [@KronicDeth](https://github.com/KronicDeth)
+  # Changelog
+  ## Bug Fixes
+  * Guard `Calcinator.Resources.params` and `Calcinator.Resources.query_options` with `is_map/1`
+  * Update to `postgrex` `0.13.2` for Elixir `1.5.0-dev` compatibility
+  * `Calcinator.Resources.query_options` `:filters` should be a map from filter name to filter value, each being a `String.t` instead of a list single-entry maps because filter names can only be used once and order should not matter.
+
 ## v2.3.0
 
 ### Enhancements

--- a/lib/calcinator.ex
+++ b/lib/calcinator.ex
@@ -551,7 +551,7 @@ defmodule Calcinator do
     end
   end
 
-  defp params_to_filters_query_option(params), do: {:ok, Map.get(params, "filter", [])}
+  defp params_to_filters_query_option(params), do: {:ok, Map.get(params, "filter", %{})}
 
   defp params_to_page_query_option(params), do: Page.from_params(params)
 

--- a/lib/calcinator/resources.ex
+++ b/lib/calcinator/resources.ex
@@ -9,11 +9,6 @@ defmodule Calcinator.Resources do
   # Types
 
   @typedoc """
-  Invoke `name` filter with `value`.
-  """
-  @type filter :: %{name :: String.t => value :: term}
-
-  @typedoc """
   ID that uniquely identifies the `struct`
   """
   @type id :: term
@@ -33,7 +28,7 @@ defmodule Calcinator.Resources do
   """
   @type query_options :: %{
     optional(:associations) => atom | [atom],
-    optional(:filters) => [filter],
+    optional(:filters) => %{String.t => String.t},
     optional(:page) => Page.t | nil,
     optional(:sorts) => Sorts.t
   }

--- a/lib/calcinator/resources/ecto/repo.ex
+++ b/lib/calcinator/resources/ecto/repo.ex
@@ -362,7 +362,7 @@ defmodule Calcinator.Resources.Ecto.Repo do
   end
 
   defp filter(module, query, query_options) when is_map(query_options) do
-    filters = Map.get(query_options, :filters, [])
+    filters = Map.get(query_options, :filters, %{})
     apply_filters(module, query, filters)
   end
 

--- a/lib/calcinator/resources/ecto/repo.ex
+++ b/lib/calcinator/resources/ecto/repo.ex
@@ -178,13 +178,14 @@ defmodule Calcinator.Resources.Ecto.Repo do
   `Ecto.Changeset.t` using the default `Ecto.Schema.t` for `module` with `params`
   """
   @spec changeset(module, Resources.params) :: Ecto.Changeset.t
-  def changeset(module, params), do: module.changeset(module.ecto_schema_module.__struct__, params)
+  def changeset(module, params) when is_map(params), do: module.changeset(module.ecto_schema_module.__struct__, params)
 
   @doc """
   1. Casts `params` into `data` using `optional_field/0` and `required_fields/0` of `module`
   2. Validates changeset with `module` `ecto_schema_module/0` `changeset/0`
   """
-  def changeset(module, data, params) do
+  @spec changeset(module, Ecto.Schema.t, Resources.params) :: Ecto.Changeset.t
+  def changeset(module, data, params) when is_map(params) do
     ecto_schema_module = module.ecto_schema_module()
 
     data
@@ -205,7 +206,7 @@ defmodule Calcinator.Resources.Ecto.Repo do
   @doc """
   Uses `query_options` as full associatons with no additions.
   """
-  def full_associations(query_options), do: Map.get(query_options, :associations, [])
+  def full_associations(query_options) when is_map(query_options), do: Map.get(query_options, :associations, [])
 
   @doc """
   Gets resource with `id` from `module` `repo/0`.
@@ -220,7 +221,7 @@ defmodule Calcinator.Resources.Ecto.Repo do
   """
   @spec get(module, Resources.id, Resources.query_options) ::
         {:ok, Ecto.Schema.t} | {:error, :not_found} | {:error, :ownership}
-  def get(module, id, opts) do
+  def get(module, id, query_options) when is_map(query_options) do
     ecto_schema_module = module.ecto_schema_module()
     repo = module.repo()
 
@@ -230,7 +231,7 @@ defmodule Calcinator.Resources.Ecto.Repo do
       nil ->
         {:error, :not_found}
       data ->
-        preload(module, data, opts)
+        preload(module, data, query_options)
     end
   end
 
@@ -249,18 +250,18 @@ defmodule Calcinator.Resources.Ecto.Repo do
   @spec insert(module, Ecto.Changeset.t | map, Resources.query_options) ::
         {:ok, Ecto.Schema.t} | {:error, :ownership} | {:error, Ecto.Changeset.t}
 
-  def insert(module, changeset = %Ecto.Changeset{}, opts) when is_map(opts) do
+  def insert(module, changeset = %Ecto.Changeset{}, query_options) when is_map(query_options) do
     repo = module.repo()
 
     with {:ok, inserted} <- wrap_ownership_error(repo, :insert, [changeset]) do
-      preload(module, inserted, opts)
+      preload(module, inserted, query_options)
     end
   end
 
-  def insert(module, params, opts) when is_map(params) and is_map(opts) do
+  def insert(module, params, query_options) when is_map(params) and is_map(query_options) do
     params
     |> module.changeset()
-    |> module.insert(opts)
+    |> module.insert(query_options)
   end
 
   @doc """
@@ -275,11 +276,11 @@ defmodule Calcinator.Resources.Ecto.Repo do
   """
   @spec list(module, Resources.query_options) ::
         {:ok, [Ecto.Schema.t], nil} | {:error, :ownership} | {:error, Document.t}
-  def list(module, opts) do
+  def list(module, query_options) when is_map(query_options) do
     repo = module.repo()
-    {:ok, query} = preload(module, module.ecto_schema_module(), opts)
+    {:ok, query} = preload(module, module.ecto_schema_module(), query_options)
 
-    with {:ok, query} <- filter(module, query, opts) do
+    with {:ok, query} <- filter(module, query, query_options) do
       case wrap_ownership_error(repo, :all, [query]) do
         {:error, :ownership} ->
           {:error, :ownership}
@@ -308,7 +309,7 @@ defmodule Calcinator.Resources.Ecto.Repo do
   """
   @spec update(module, Ecto.Changeset.t, Resources.query_options) ::
         {:ok, Ecto.Schema.t} | {:error, :ownership} | {:error, Ecto.Changeset.t}
-  def update(module, changeset, query_options) do
+  def update(module, changeset, query_options) when is_map(query_options) do
     repo = module.repo()
 
     with {:ok, updated} <- wrap_ownership_error(repo, :update, [changeset]) do
@@ -330,7 +331,7 @@ defmodule Calcinator.Resources.Ecto.Repo do
   """
   @spec update(module, Ecto.Schema.t, Resources.params, Resources.query_options) ::
           {:ok, Ecto.Schema.t} | {:error, Ecto.Changeset.t}
-  def update(module, data, params, query_options) do
+  def update(module, data, params, query_options) when is_map(params) and is_map(query_options) do
     data
     |> module.changeset(params)
     |> module.update(query_options)
@@ -365,7 +366,7 @@ defmodule Calcinator.Resources.Ecto.Repo do
     apply_filters(module, query, filters)
   end
 
-  defp preload(module, data_or_queryable, query_options) do
+  defp preload(module, data_or_queryable, query_options) when is_map(query_options) do
     ecto_schema_module = module.ecto_schema_module()
 
     case data_or_queryable do
@@ -376,7 +377,7 @@ defmodule Calcinator.Resources.Ecto.Repo do
     end
   end
 
-  defp preload_data(module, data, query_options) do
+  defp preload_data(module, data, query_options) when is_map(query_options) do
     repo = module.repo()
 
     case wrap_ownership_error(repo, :preload, [data, module.full_associations(query_options)]) do
@@ -406,7 +407,7 @@ defmodule Calcinator.Resources.Ecto.Repo do
   end
 
   @spec update_preload(module, Ecto.Schema.t, Resources.query_options) :: {:ok, Ecto.Schema.t} | {:error, :ownership}
-  defp update_preload(module, updated, query_options) do
+  defp update_preload(module, updated, query_options) when is_map(query_options) do
     preloads = module.full_associations(query_options)
     repo = module.repo()
     unloaded_updated = unload_preloads(updated, preloads)

--- a/mix.exs
+++ b/mix.exs
@@ -29,7 +29,7 @@ defmodule Calcinator.Mixfile do
       test_coverage: [
         tool: ExCoveralls
       ],
-      version: "2.3.0"
+      version: "2.3.1"
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -3,7 +3,7 @@
   "certifi": {:hex, :certifi, "1.0.0", "1c787a85b1855ba354f0b8920392c19aa1d06b0ee1362f9141279620a5be2039", [:rebar3], []},
   "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], []},
   "credo": {:hex, :credo, "0.7.3", "9827ab04002186af1aec014a811839a06f72aaae6cd5eed3919b248c8767dbf3", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, optional: false]}]},
-  "db_connection": {:hex, :db_connection, "1.1.0", "b2b88db6d7d12f99997b584d09fad98e560b817a20dab6a526830e339f54cdb3", [:mix], [{:connection, "~> 1.0.2", [hex: :connection, optional: false]}, {:poolboy, "~> 1.5", [hex: :poolboy, optional: true]}, {:sbroker, "~> 1.0", [hex: :sbroker, optional: true]}]},
+  "db_connection": {:hex, :db_connection, "1.1.2", "2865c2a4bae0714e2213a0ce60a1b12d76a6efba0c51fbda59c9ab8d1accc7a8", [:mix], [{:connection, "~> 1.0.2", [hex: :connection, optional: false]}, {:poolboy, "~> 1.5", [hex: :poolboy, optional: true]}, {:sbroker, "~> 1.0", [hex: :sbroker, optional: true]}]},
   "decimal": {:hex, :decimal, "1.3.1", "157b3cedb2bfcb5359372a7766dd7a41091ad34578296e951f58a946fcab49c6", [:mix], []},
   "dialyze": {:hex, :dialyze, "0.2.1", "9fb71767f96649020d769db7cbd7290059daff23707d6e851e206b1fdfa92f9d", [:mix], []},
   "earmark": {:hex, :earmark, "1.2.0", "bf1ce17aea43ab62f6943b97bd6e3dc032ce45d4f787504e3adf738e54b42f3a", [:mix], []},
@@ -28,5 +28,5 @@
   "plug": {:hex, :plug, "1.3.5", "7503bfcd7091df2a9761ef8cecea666d1f2cc454cbbaf0afa0b6e259203b7031", [:mix], [{:cowboy, "~> 1.0.1 or ~> 1.1", [hex: :cowboy, optional: true]}, {:mime, "~> 1.0", [hex: :mime, optional: false]}]},
   "poison": {:hex, :poison, "2.2.0", "4763b69a8a77bd77d26f477d196428b741261a761257ff1cf92753a0d4d24a63", [:mix], []},
   "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], []},
-  "postgrex": {:hex, :postgrex, "0.13.0", "e101ab47d0725955c5c8830ae8812412992e02e4bd9db09e17abb0a5d82d09c7", [:mix], [{:connection, "~> 1.0", [hex: :connection, optional: false]}, {:db_connection, "~> 1.1", [hex: :db_connection, optional: false]}, {:decimal, "~> 1.0", [hex: :decimal, optional: false]}]},
+  "postgrex": {:hex, :postgrex, "0.13.2", "2b88168fc6a5456a27bfb54ccf0ba4025d274841a7a3af5e5deb1b755d95154e", [:mix], [{:connection, "~> 1.0", [hex: :connection, optional: false]}, {:db_connection, "~> 1.1", [hex: :db_connection, optional: false]}, {:decimal, "~> 1.0", [hex: :decimal, optional: false]}]},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], []}}


### PR DESCRIPTION
# Changelog
## Bug Fixes
* Guard `Calcinator.Resources.params` and `Calcinator.Resources.query_options` with `is_map/1`
* Update to `postgrex` `0.13.2` for Elixir `1.5.0-dev` compatibility
* `Calcinator.Resources.query_options` `:filters` should be a map from filter name to filter value, each being a `String.t` instead of a list single-entry maps because filter names can only be used once and order should not matter.