### PR TITLE
VPP-2250: Distinct Calcinatator.Resources.Ecto.Repo.list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,12 +40,16 @@
 
 # Changelog
 
+## v2.4.0
+
+* [#18](https://github.com/C-S-D/calcinator/pull/18) - [@KronicDeth](https://github.com/KronicDeth)
+  * JSONAPI filter values that allow multiple values, similar to includes, are comma separated without spaces, instead of having to do `String.split(comma_separated_values, ",")` in all filters that accept multiple values, `Calcinator.Resources.split_filter_value/1` can be used.
+  * Pass the final `query` with all filters applied through `distinct(query, true)`, so that filters don't need to ensure they return distinct results, which is an expectation of JSONAPI.
+
 ## v2.3.1
 
 ### Bug Fixes
 * [#17](https://github.com/C-S-D/calcinator/pull/17) - [@KronicDeth](https://github.com/KronicDeth)
-  # Changelog
-  ## Bug Fixes
   * Guard `Calcinator.Resources.params` and `Calcinator.Resources.query_options` with `is_map/1`
   * Update to `postgrex` `0.13.2` for Elixir `1.5.0-dev` compatibility
   * `Calcinator.Resources.query_options` `:filters` should be a map from filter name to filter value, each being a `String.t` instead of a list single-entry maps because filter names can only be used once and order should not matter.

--- a/coveralls.json
+++ b/coveralls.json
@@ -1,5 +1,5 @@
 {
   "coverage_options": {
-    "minimum_coverage": 22.712
+    "minimum_coverage": 23.746
   }
 }

--- a/lib/calcinator/resources.ex
+++ b/lib/calcinator/resources.ex
@@ -205,6 +205,18 @@ defmodule Calcinator.Resources do
   end
 
   @doc """
+  JSONAPI filter values that allow multiple values, similar to includes, are comma separated without spaces, instead of
+  having to do `String.split(comma_separated_values, ",")` in all filters that accept multiple values, this function can
+  be used.
+
+      iex> Calcinator.Resources.split_filter_value("1,2,3")
+      ["1", "2", "3"]
+
+  """
+  @spec split_filter_value(String.t) :: [String.t]
+  def split_filter_value(comma_separated), do: String.split(comma_separated, ",")
+
+  @doc """
   Error when a filter `name` is not supported by the callback module.
 
       iex> Calcinator.Resources.unknown_filter("name")

--- a/lib/calcinator/resources/ecto/repo.ex
+++ b/lib/calcinator/resources/ecto/repo.ex
@@ -55,6 +55,7 @@ defmodule Calcinator.Resources.Ecto.Repo do
 
   import Calcinator.Resources, only: [unknown_filter: 1]
   import Ecto.Changeset, only: [cast: 3]
+  import Ecto.Query, only: [distinct: 2]
 
   # Types
 
@@ -281,7 +282,7 @@ defmodule Calcinator.Resources.Ecto.Repo do
     {:ok, query} = preload(module, module.ecto_schema_module(), query_options)
 
     with {:ok, query} <- filter(module, query, query_options) do
-      case wrap_ownership_error(repo, :all, [query]) do
+      case wrap_ownership_error(repo, :all, [distinct(query, true)]) do
         {:error, :ownership} ->
           {:error, :ownership}
         all ->

--- a/priv/repo/migrations/20170426152140_add_posts.exs
+++ b/priv/repo/migrations/20170426152140_add_posts.exs
@@ -1,0 +1,12 @@
+defmodule Calcinator.Resources.Ecto.Repo.Repo.Migrations.AddPosts do
+  use Ecto.Migration
+
+  def change do
+    create table(:posts) do
+      add :author_id, references(:authors), null: false
+      add :body,      :string,              null: false
+
+      timestamps()
+    end
+  end
+end

--- a/test/support/calcinator/resources/ecto/repo/factory.ex
+++ b/test/support/calcinator/resources/ecto/repo/factory.ex
@@ -1,5 +1,5 @@
 defmodule Calcinator.Resources.Ecto.Repo.Factory do
-  alias Calcinator.Resources.TestAuthor
+  alias Calcinator.Resources.{TestAuthor, TestPost}
 
   use ExMachina.Ecto, repo: Calcinator.Resources.Ecto.Repo.Repo
 
@@ -8,6 +8,13 @@ defmodule Calcinator.Resources.Ecto.Repo.Factory do
   def test_author_factory do
     %TestAuthor{
       name: Faker.Name.name()
+    }
+  end
+
+  def test_post_factory do
+    %TestPost{
+      author: build(:test_author),
+      body: Faker.Lorem.paragraphs()
     }
   end
 end

--- a/test/support/calcinator/resources/ecto/repo/test_authors.ex
+++ b/test/support/calcinator/resources/ecto/repo/test_authors.ex
@@ -1,7 +1,7 @@
 defmodule Calcinator.Resources.Ecto.Repo.TestAuthors do
   use Calcinator.Resources.Ecto.Repo
 
-  import Calcinator.Resources, only: [unknown_filter: 1]
+  import Calcinator.Resources, only: [split_filter_value: 1, unknown_filter: 1]
   import Ecto.Query, only: [where: 3]
 
   # Functions
@@ -11,7 +11,7 @@ defmodule Calcinator.Resources.Ecto.Repo.TestAuthors do
   def ecto_schema_module(), do: Calcinator.Resources.TestAuthor
 
   def filter(query, "id", comma_separated_ids) do
-    {:ok, where(query, [i], i.id in ^String.split(comma_separated_ids, ","))}
+    {:ok, where(query, [i], i.id in ^split_filter_value(comma_separated_ids))}
   end
   def filter(_,     name, _), do: {:error, unknown_filter(name)}
 

--- a/test/support/calcinator/resources/ecto/repo/test_authors.ex
+++ b/test/support/calcinator/resources/ecto/repo/test_authors.ex
@@ -2,7 +2,7 @@ defmodule Calcinator.Resources.Ecto.Repo.TestAuthors do
   use Calcinator.Resources.Ecto.Repo
 
   import Calcinator.Resources, only: [split_filter_value: 1, unknown_filter: 1]
-  import Ecto.Query, only: [where: 3]
+  import Ecto.Query, only: [from: 2, where: 3]
 
   # Functions
 
@@ -10,10 +10,18 @@ defmodule Calcinator.Resources.Ecto.Repo.TestAuthors do
 
   def ecto_schema_module(), do: Calcinator.Resources.TestAuthor
 
-  def filter(query, "id", comma_separated_ids) do
+  def filter(query, "id",         comma_separated_ids) do
     {:ok, where(query, [i], i.id in ^split_filter_value(comma_separated_ids))}
   end
-  def filter(_,     name, _), do: {:error, unknown_filter(name)}
+
+  def filter(query, "posts.body", body_substring) do
+    filter_query = from i in query,
+                        join: p in assoc(i, :posts),
+                        where: ilike(p.body, ^"%#{body_substring}%")
+    {:ok, filter_query}
+  end
+
+  def filter(_,     name,         _), do: {:error, unknown_filter(name)}
 
   def repo(), do: Calcinator.Resources.Ecto.Repo.Repo
 end

--- a/test/support/calcinator/resources/test_post.ex
+++ b/test/support/calcinator/resources/test_post.ex
@@ -6,6 +6,8 @@ defmodule Calcinator.Resources.TestPost do
   use Ecto.Schema
 
   schema "posts" do
+    field :body, :string
+
     timestamps()
 
     belongs_to :author, Calcinator.Resources.TestAuthor


### PR DESCRIPTION
# Changelog
## Enhancements
* JSONAPI filter values that allow multiple values, similar to includes, are comma separated without spaces, instead of having to do `String.split(comma_separated_values, ",")` in all filters that accept multiple values, `Calcinator.Resources.split_filter_value/1` can be used.
* Pass the final `query` with all filters applied through `distinct(query, true)`, so that filters don't need to ensure they return distinct results, which is an expectation of JSONAPI.