### PR TITLE
VPP-2317: Calcinator sandbox errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,44 +3,80 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [Changelog](#changelog)
-  - [v2.3.0](#v230)
+  - [v3.0.0](#v300)
     - [Enhancements](#enhancements)
-  - [v2.2.0](#v220)
-    - [Enhancements](#enhancements-1)
-  - [v2.1.0](#v210)
-    - [Enhancements](#enhancements-2)
     - [Bug Fixes](#bug-fixes)
-  - [v2.0.0](#v200)
-    - [Enhancements](#enhancements-3)
-    - [Bug Fixes](#bug-fixes-1)
     - [Incompatible Changes](#incompatible-changes)
-  - [v1.7.0](#v170)
+  - [v2.4.0](#v240)
+    - [Enhancements](#enhancements-1)
+  - [v2.3.1](#v231)
+    - [Bug Fixes](#bug-fixes-1)
+  - [v2.3.0](#v230)
+    - [Enhancements](#enhancements-2)
+  - [v2.2.0](#v220)
+    - [Enhancements](#enhancements-3)
+  - [v2.1.0](#v210)
     - [Enhancements](#enhancements-4)
     - [Bug Fixes](#bug-fixes-2)
-  - [v1.6.0](#v160)
+  - [v2.0.0](#v200)
     - [Enhancements](#enhancements-5)
-  - [v1.5.1](#v151)
     - [Bug Fixes](#bug-fixes-3)
-  - [v1.5.0](#v150)
+    - [Incompatible Changes](#incompatible-changes-1)
+  - [v1.7.0](#v170)
     - [Enhancements](#enhancements-6)
     - [Bug Fixes](#bug-fixes-4)
-  - [v1.4.0](#v140)
+  - [v1.6.0](#v160)
     - [Enhancements](#enhancements-7)
-  - [v1.3.0](#v130)
-    - [Enhancements](#enhancements-8)
+  - [v1.5.1](#v151)
     - [Bug Fixes](#bug-fixes-5)
-  - [v1.2.0](#v120)
-    - [Enhancements](#enhancements-9)
+  - [v1.5.0](#v150)
+    - [Enhancements](#enhancements-8)
     - [Bug Fixes](#bug-fixes-6)
-  - [v1.1.0](#v110)
+  - [v1.4.0](#v140)
+    - [Enhancements](#enhancements-9)
+  - [v1.3.0](#v130)
     - [Enhancements](#enhancements-10)
     - [Bug Fixes](#bug-fixes-7)
+  - [v1.2.0](#v120)
+    - [Enhancements](#enhancements-11)
+    - [Bug Fixes](#bug-fixes-8)
+  - [v1.1.0](#v110)
+    - [Enhancements](#enhancements-12)
+    - [Bug Fixes](#bug-fixes-9)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 # Changelog
 
+## v3.0.0
+
+### Enhancements
+* [#19](https://github.com/C-S-D/calcinator/pull/19) - [@KronicDeth](https://github.com/KronicDeth)
+  * Can now return (and is preferred to return instead of a timeout exit) `{:error, :timeout}` from all `Calcinator.Resources` action `@callbacks`.  The following were added:
+    * `Calcinator.Resources.delete/2`
+    * `Calcinator.Resources.get/2`
+    * `Calcinator.Resources.insert/2`
+    * `Calcinator.Resources.update/2`
+    * `Calcinator.Resources.update/3`
+
+### Bug Fixes
+* [#19](https://github.com/C-S-D/calcinator/pull/19) - [@KronicDeth](https://github.com/KronicDeth)
+  * Previously, the `Calcinator` actions (`create/2`, `delete/2`, `get_related_resource/3`, `index/3`, `show/2`, `show_relationship/3`, and `update/2`) `@spec` and `@doc` include (hopefully) all the errors they can return now
+    * `{:error, :sandbox_access_disallowed}`
+    * `{:error, :sandbox_token_missing}`
+    * `{:error, :timeout}`
+  * `@callback`s with the same name/arity can only have on `@doc`, so the second form of `Calcinator.Resources.insert/2` did not show up.
+  * Change first level of header to `##` to match style guide for ex_doc in `Calcinator.Resources`.
+  * Rearrange `Calcinator.Resources.update/2`, so it's before `Calcinator.Resources.update/3` to match doc sorted order.
+
+### Incompatible Changes
+* [#19](https://github.com/C-S-D/calcinator/pull/19) - [@KronicDeth](https://github.com/KronicDeth)
+  * `Calcinator.Resources.allow_sandbox_access/1` must now return `:ok | {:error, :sandbox_access_disallowed}`.  The previous `{:already, :allowed | :owner}` maps to `:ok` while `:not_found` maps to `{:error, :sandbox_access_disallowed}`.
+  * If you previously had total coverage for all return types from `Calcinator` actions, they now also return `{:error, :sandbox_access_disallowed}` and `{:error, :timeout}`.  Previously, instead of `{:error, :sandbox_access_disallowed}`, `:not_found` may been returned, but that was a bug that leaked an implementation detail from how `DBConnection.Ownership` works, so it was removed.
+
 ## v2.4.0
+
+### Enhancements
 
 * [#18](https://github.com/C-S-D/calcinator/pull/18) - [@KronicDeth](https://github.com/KronicDeth)
   * JSONAPI filter values that allow multiple values, similar to includes, are comma separated without spaces, instead of having to do `String.split(comma_separated_values, ",")` in all filters that accept multiple values, `Calcinator.Resources.split_filter_value/1` can be used.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ If [available in Hex](https://hex.pm/docs/publish), the package can be installed
 
     ```elixir
     def deps do
-      [{:calcinator, "~> 1.0.0"}]
+      [{:calcinator, "~> 3.0"}]
     end
     ```
 

--- a/lib/calcinator.ex
+++ b/lib/calcinator.ex
@@ -64,6 +64,7 @@ defmodule Calcinator do
 
   ## Client Functions
 
+  @spec allow_sandbox_access(t, params) :: :ok | {:error, :sandbox_access_disallowed} | {:error, :sandbox_token_missing}
   def allow_sandbox_access(state = %__MODULE__{resources_module: resources_module}, params) do
     allow_sandbox_access(state, params, resources_module.sandboxed?())
   end
@@ -138,6 +139,10 @@ defmodule Calcinator do
   ## Returns
 
     * `{:error, :ownership}` - connection to backing store was not owned by the calling process
+    * `{:error, :sandbox_access_disallowed}` - Sandbox token was required and present, but did not have the correct
+      information to grant access.
+    * `{:error, :sandbox_token_missing}` - Sandbox token was required (because `state` `resources_module`
+      `Calcinator.Resources.sandboxed?/0` returned `true`), but `params["meta"]["beam"]` was not present.
     * `{:error, :unauthorized}` - if `state` `authorization_module` `can?(subject, :create, ecto_schema_module)` or
       `can?(subject, :create, %Ecto.Changeset{})` returns `false`
     * `{:error, Alembic.Document.t}` - if `params` is not a valid JSONAPI document
@@ -146,6 +151,8 @@ defmodule Calcinator do
 
   """
   @spec create(t, params) :: {:error, :ownership} |
+                             {:error, :sandbox_access_disallowed} |
+                             {:error, :sandbox_token_missing} |
                              {:error, :unauthorized} |
                              {:error, Document.t} |
                              {:error, Ecto.Changeset.t} |
@@ -184,6 +191,10 @@ defmodule Calcinator do
 
     * `{:error, {:not_found, "id"}}` - The "id" did not correspond to resource in the backing store
     * `{:error, :ownership}` - connection to backing store was not owned by the calling process
+    * `{:error, :sandbox_access_disallowed}` - Sandbox token was required and present, but did not have the correct
+      information to grant access.
+    * `{:error, :sandbox_token_missing}` - Sandbox token was required (because `state` `resources_module`
+      `Calcinator.Resources.sandboxed?/0` returned `true`), but `params["meta"]["beam"]` was not present.
     * `{:error, :unauthorized}` - The `state` `subject` is not authorized to delete the resource
     * `{:error, Ecto.Changeset.t}` - the deletion failed with the errors in `Ecto.Changeset.t`
     * `:ok` - resource was successfully deleted
@@ -192,6 +203,8 @@ defmodule Calcinator do
   @spec delete(t, params) :: :ok |
                              {:error, {:not_found, parameter}} |
                              {:error, :ownership} |
+                             {:error, :sandbox_access_disallowed} |
+                             {:error, :sandbox_token_missing} |
                              {:error, :unauthorized} |
                              {:error, Ecto.Changeset.t}
   def delete(state = %__MODULE__{}, params) do
@@ -221,12 +234,20 @@ defmodule Calcinator do
     * `{:error, {:not_found, id_key}}` - The value of the `id_key` key in `params` did not correspond to a resource in
       the backing store.
     * `{:error, :ownership}` - connection to backing store was not owned by the calling process
+    * `{:error, :sandbox_access_disallowed}` - Sandbox token was required and present, but did not have the correct
+      information to grant access.
+    * `{:error, :sandbox_token_missing}` - Sandbox token was required (because `state` `resources_module`
+      `Calcinator.Resources.sandboxed?/0` returned `true`), but `params["meta"]["beam"]` was not present.
     * `{:error, :unauthorized}` - if the either the source or related resource cannot be shown
     * `{:ok, rendered}` - rendered view of related resource
 
   """
-  @spec get_related_resource(t, params, map) ::
-        {:error, {:not_found, parameter}} | {:error, :ownership} | {:error, :unauthorized} | {:ok, rendered}
+  @spec get_related_resource(t, params, map) :: {:error, {:not_found, parameter}} |
+                                                {:error, :ownership} |
+                                                {:error, :sandbox_access_disallowed} |
+                                                {:error, :sandbox_token_missing} |
+                                                {:error, :unauthorized} |
+                                                {:ok, rendered}
   def get_related_resource(
         state = %__MODULE__{},
         params,
@@ -252,6 +273,10 @@ defmodule Calcinator do
   ## Returns
 
     * `{:error, :ownership}` - connection to backing store was not owned by the calling process
+    * `{:error, :sandbox_access_disallowed}` - Sandbox token was required and present, but did not have the correct
+      information to grant access.
+    * `{:error, :sandbox_token_missing}` - Sandbox token was required (because `state` `resources_module`
+      `Calcinator.Resources.sandboxed?/0` returned `true`), but `params["meta"]["beam"]` was not present.
     * `{:error, :timeout}` - if the backing store for `state` `resources_module` times out when calling `list/1`.
     * `{:error, :unauthorized}` - if `state` `authorization_module` `can?(subject, :index, ecto_schema_module)` returns
       `false`
@@ -259,8 +284,13 @@ defmodule Calcinator do
     * `{:ok, rendered}` - the rendered resources with (optional) pagination in the `"meta"`.
 
   """
-  @spec index(t, params, %{required(:base_uri) => URI.t}) ::
-        {:error, :timeout} | {:error, :unauthorized} | {:error, Document.t} | {:ok, rendered}
+  @spec index(t, params, %{required(:base_uri) => URI.t}) :: {:error, :ownership} |
+                                                             {:error, :sandbox_access_disallowed} |
+                                                             {:error, :sandbox_token_missing} |
+                                                             {:error, :timeout} |
+                                                             {:error, :unauthorized} |
+                                                             {:error, Document.t} |
+                                                             {:ok, rendered}
   def index(state = %__MODULE__{
                       ecto_schema_module: ecto_schema_module,
                       subject: subject,
@@ -298,6 +328,10 @@ defmodule Calcinator do
 
     * `{:error, {:not_found, "id"}}` - The "id" did not correspond to resource in the backing store
     * `{:error, :ownership}` - connection to backing store was not owned by the calling process
+    * `{:error, :sandbox_access_disallowed}` - Sandbox token was required and present, but did not have the correct
+      information to grant access.
+    * `{:error, :sandbox_token_missing}` - Sandbox token was required (because `state` `resources_module`
+      `Calcinator.Resources.sandboxed?/0` returned `true`), but `params["meta"]["beam"]` was not present.
     * `{:error, :unauthorized}` - `state` `authorization_module` `can?(subject, :show, got)` returns `false`
     * `{:error, Alembic.Document.t}` - `params` is not valid JSONAPI
     * `{:ok, rendered}` - rendered resource
@@ -305,6 +339,8 @@ defmodule Calcinator do
   """
   @spec show(t, params) :: {:error, {:not_found, parameter}} |
                            {:error, :ownership} |
+                           {:error, :sandbox_access_disallowed} |
+                           {:error, :sandbox_token_missing} |
                            {:error, :unauthorized} |
                            {:error, Document.t} |
                            {:ok, rendered}
@@ -334,12 +370,20 @@ defmodule Calcinator do
     * `{:error, {:not_found, id_key}}` - The value of the `id_key` key in `params` did not correspond to a resource in
       the backing store.
     * `{:error, :ownership}` - connection to backing store was not owned by the calling process
+    * `{:error, :sandbox_access_disallowed}` - Sandbox token was required and present, but did not have the correct
+      information to grant access.
+    * `{:error, :sandbox_token_missing}` - Sandbox token was required (because `state` `resources_module`
+      `Calcinator.Resources.sandboxed?/0` returned `true`), but `params["meta"]["beam"]` was not present.
     * `{:error, :unauthorized}` - if the either the source or related resource cannot be shown
     * `{:ok, rendered}` - rendered view of relationship
 
   """
-  @spec show_relationship(t, params, map) ::
-        {:error, {:not_found, parameter}} | {:error, :ownership} | {:error, :unauthorized} | {:ok, rendered}
+  @spec show_relationship(t, params, map) :: {:error, {:not_found, parameter}} |
+                                             {:error, :ownership} |
+                                             {:error, :sandbox_access_disallowed} |
+                                             {:error, :sandbox_token_missing} |
+                                             {:error, :unauthorized} |
+                                             {:ok, rendered}
   def show_relationship(
         state = %__MODULE__{},
         params,
@@ -368,6 +412,10 @@ defmodule Calcinator do
     * `{:error, {:not_found, "id"}}` - get failed or update failed because the resource was deleted between the get and
       update.
     * `{:error, :ownership}` - connection to backing store was not owned by the calling process
+    * `{:error, :sandbox_access_disallowed}` - Sandbox token was required and present, but did not have the correct
+      information to grant access.
+    * `{:error, :sandbox_token_missing}` - Sandbox token was required (because `state` `resources_module`
+      `Calcinator.Resources.sandboxed?/0` returned `true`), but `params["meta"]["beam"]` was not present.
     * `{:error, :unauthorized}` - the resource either can't be shown or can't be updated
     * `{:error, Alembic.Document.t}` - the `params` are not valid JSONAPI
     * `{:error, Ecto.Changeset.t}` - validations error when updating
@@ -377,6 +425,8 @@ defmodule Calcinator do
   @spec update(t, params) :: {:error, :bad_gateway} |
                              {:error, {:not_found, parameter}} |
                              {:error, :ownership} |
+                             {:error, :sandbox_access_disallowed} |
+                             {:error, :sandbox_token_missing} |
                              {:error, :unauthorized} |
                              {:error, Document.t} |
                              {:error, Ecto.Changeset.t} |
@@ -418,6 +468,10 @@ defmodule Calcinator do
       }
     )
   end
+
+  @spec allow_sandbox_access(t, map, sandboxed? :: false) :: :ok
+  @spec allow_sandbox_access(t, map, sandboxed? :: true) ::
+          :ok | {:error, :sandbox_access_disallowed} | {:error, :sandbox_token_missing}
 
   defp allow_sandbox_access(
         %__MODULE__{resources_module: resources_module},
@@ -462,8 +516,11 @@ defmodule Calcinator do
     |> status_changeset()
   end
 
-  @spec create_changeset(t, Ecto.Changeset.t, params) ::
-        {:ok, struct} | {:error, Document.t} | {:error, Ecto.Changeset.t}
+  @spec create_changeset(t, Ecto.Changeset.t, params) :: {:ok, struct} |
+                                                         {:error, :sandbox_access_disallowed} |
+                                                         {:error, :sandbox_token_missing} |
+                                                         {:error, Document.t} |
+                                                         {:error, Ecto.Changeset.t}
   defp create_changeset(state = %__MODULE__{resources_module: resources_module}, changeset = %Ecto.Changeset{}, params)
       when not is_nil(resources_module) and is_atom(resources_module) do
     with {:ok, query_options} <- params_to_query_options(state, params),
@@ -567,8 +624,11 @@ defmodule Calcinator do
     end
   end
 
-  @spec related_property(t, params, map) ::
-        {:error, {:not_found, parameter}} | {:error, :unauthorized} | {:ok, rendered}
+  @spec related_property(t, params, map) :: {:error, {:not_found, parameter}} |
+                                            {:error, :sandbox_access_disallowed} |
+                                            {:error, :sandbox_token_missing} |
+                                            {:error, :unauthorized} |
+                                            {:ok, rendered}
   defp related_property(
         state = %__MODULE__{subject: subject, view_module: view_module},
         params,
@@ -579,7 +639,8 @@ defmodule Calcinator do
           }
         }
       ) do
-    with {:ok, source} <- get_source(state, params, source_option),
+    with :ok <- allow_sandbox_access(state, params),
+         {:ok, source} <- get_source(state, params, source_option),
          :ok <- can(state, :show, source),
          {:ok, authorized_related} <- get_maybe_authorized_related(state, source, association) do
       {

--- a/lib/calcinator.ex
+++ b/lib/calcinator.ex
@@ -143,6 +143,8 @@ defmodule Calcinator do
       information to grant access.
     * `{:error, :sandbox_token_missing}` - Sandbox token was required (because `state` `resources_module`
       `Calcinator.Resources.sandboxed?/0` returned `true`), but `params["meta"]["beam"]` was not present.
+    * `{:error, :timeout}` - if the backing store for `state` `resources_module` times out when calling
+      `Calcinator.Resources.insert/2`.
     * `{:error, :unauthorized}` - if `state` `authorization_module` `can?(subject, :create, ecto_schema_module)` or
       `can?(subject, :create, %Ecto.Changeset{})` returns `false`
     * `{:error, Alembic.Document.t}` - if `params` is not a valid JSONAPI document
@@ -153,6 +155,7 @@ defmodule Calcinator do
   @spec create(t, params) :: {:error, :ownership} |
                              {:error, :sandbox_access_disallowed} |
                              {:error, :sandbox_token_missing} |
+                             {:error, :timeout} |
                              {:error, :unauthorized} |
                              {:error, Document.t} |
                              {:error, Ecto.Changeset.t} |
@@ -195,6 +198,8 @@ defmodule Calcinator do
       information to grant access.
     * `{:error, :sandbox_token_missing}` - Sandbox token was required (because `state` `resources_module`
       `Calcinator.Resources.sandboxed?/0` returned `true`), but `params["meta"]["beam"]` was not present.
+    * `{:error, :timeout}` - if the backing store for `state` `resources_module` times out when calling
+      `Calcinator.Resources.get/2` or `Calcinator.Resources.delete/1`.
     * `{:error, :unauthorized}` - The `state` `subject` is not authorized to delete the resource
     * `{:error, Ecto.Changeset.t}` - the deletion failed with the errors in `Ecto.Changeset.t`
     * `:ok` - resource was successfully deleted
@@ -205,6 +210,7 @@ defmodule Calcinator do
                              {:error, :ownership} |
                              {:error, :sandbox_access_disallowed} |
                              {:error, :sandbox_token_missing} |
+                             {:error, :timeout} |
                              {:error, :unauthorized} |
                              {:error, Ecto.Changeset.t}
   def delete(state = %__MODULE__{}, params) do
@@ -238,6 +244,8 @@ defmodule Calcinator do
       information to grant access.
     * `{:error, :sandbox_token_missing}` - Sandbox token was required (because `state` `resources_module`
       `Calcinator.Resources.sandboxed?/0` returned `true`), but `params["meta"]["beam"]` was not present.
+    * `{:error, :timeout}` - if the backing store for `state` `resources_module` times out when calling
+      `Calcinator.Resources.get/2`.
     * `{:error, :unauthorized}` - if the either the source or related resource cannot be shown
     * `{:ok, rendered}` - rendered view of related resource
 
@@ -246,6 +254,7 @@ defmodule Calcinator do
                                                 {:error, :ownership} |
                                                 {:error, :sandbox_access_disallowed} |
                                                 {:error, :sandbox_token_missing} |
+                                                {:error, :timeout} |
                                                 {:error, :unauthorized} |
                                                 {:ok, rendered}
   def get_related_resource(
@@ -332,6 +341,8 @@ defmodule Calcinator do
       information to grant access.
     * `{:error, :sandbox_token_missing}` - Sandbox token was required (because `state` `resources_module`
       `Calcinator.Resources.sandboxed?/0` returned `true`), but `params["meta"]["beam"]` was not present.
+    * `{:error, :timeout}` - if the backing store for `state` `resources_module` times out when calling
+      `Calcinator.Resources.get/2`.
     * `{:error, :unauthorized}` - `state` `authorization_module` `can?(subject, :show, got)` returns `false`
     * `{:error, Alembic.Document.t}` - `params` is not valid JSONAPI
     * `{:ok, rendered}` - rendered resource
@@ -341,6 +352,7 @@ defmodule Calcinator do
                            {:error, :ownership} |
                            {:error, :sandbox_access_disallowed} |
                            {:error, :sandbox_token_missing} |
+                           {:error, :timeout} |
                            {:error, :unauthorized} |
                            {:error, Document.t} |
                            {:ok, rendered}
@@ -374,6 +386,8 @@ defmodule Calcinator do
       information to grant access.
     * `{:error, :sandbox_token_missing}` - Sandbox token was required (because `state` `resources_module`
       `Calcinator.Resources.sandboxed?/0` returned `true`), but `params["meta"]["beam"]` was not present.
+    * `{:error, :timeout}` - if the backing store for `state` `resources_module` times out when calling
+      `Calcinator.Resources.get/2`.
     * `{:error, :unauthorized}` - if the either the source or related resource cannot be shown
     * `{:ok, rendered}` - rendered view of relationship
 
@@ -382,6 +396,7 @@ defmodule Calcinator do
                                              {:error, :ownership} |
                                              {:error, :sandbox_access_disallowed} |
                                              {:error, :sandbox_token_missing} |
+                                             {:error, :timeout} |
                                              {:error, :unauthorized} |
                                              {:ok, rendered}
   def show_relationship(
@@ -416,6 +431,8 @@ defmodule Calcinator do
       information to grant access.
     * `{:error, :sandbox_token_missing}` - Sandbox token was required (because `state` `resources_module`
       `Calcinator.Resources.sandboxed?/0` returned `true`), but `params["meta"]["beam"]` was not present.
+    * `{:error, :timeout}` - if the backing store for `state` `resources_module` times out when calling
+      `Calcinator.Resources.get/2` or `Calcinator.Resources.update/2`.
     * `{:error, :unauthorized}` - the resource either can't be shown or can't be updated
     * `{:error, Alembic.Document.t}` - the `params` are not valid JSONAPI
     * `{:error, Ecto.Changeset.t}` - validations error when updating

--- a/lib/calcinator/resources.ex
+++ b/lib/calcinator/resources.ex
@@ -64,9 +64,10 @@ defmodule Calcinator.Resources do
 
     * `{:ok, struct}` - the delete succeeded and the returned struct is the state before delete
     * `{:error, :ownership}` - connection to backing store was not owned by the calling process
+    * `{:error, :timeout}` - timeout occured while deleting `struct` from backing store.
     * `{:error, Ecto.Changeset.t}` - errors while deleting the `struct`.  `Ecto.Changeset.t` `errors` contains errors.
   """
-  @callback delete(struct) :: {:ok, struct} | {:error, :ownership} | {:error, Ecto.Changeset.t}
+  @callback delete(struct) :: {:ok, struct} | {:error, :ownership} | {:error, :timeout} | {:error, Ecto.Changeset.t}
 
   @doc """
   Gets a single `struct`
@@ -76,12 +77,15 @@ defmodule Calcinator.Resources do
     * `{:ok, struct}` - `id` was found.
     * `{:error, :not_found}` - `id` was not found.
     * `{:error, :ownership}` - connection to backing store was not owned by the calling process
-    * `{:error, :timeout}` - timeout occured while getting `id` from backing store .
+    * `{:error, :timeout}` - timeout occured while getting `id` from backing store.
     * `{:error, reason}` - an error occurred with the backing store for `reason` that is backing store specific.
 
   """
-  @callback get(id, query_options) ::
-            {:ok, struct} | {:error, :not_found} | {:error, :ownership} | {:error, :timeout} | {:error, reason :: term}
+  @callback get(id, query_options) :: {:ok, struct} |
+                                      {:error, :not_found} |
+                                      {:error, :ownership} |
+                                      {:error, :timeout} |
+                                      {:error, reason :: term}
 
   @doc """
   Inserts `changeset` into a single new `struct`
@@ -89,9 +93,11 @@ defmodule Calcinator.Resources do
   # Returns
     * `{:ok, struct}` - `changeset` was inserted into `struct`
     * `{:error, :ownership}` - connection to backing store was not owned by the calling process
+    * `{:error, :timeout}` - timeout occured while inserting changeset into backing store.
     * `{:error, Ecto.Changeset.t}` - insert failed.  `Ecto.Changeset.t` `errors` contain errors.
   """
-  @callback insert(Ecto.Changeset.t, query_options) :: {:ok, struct} | {:error, :ownership} | {:error, Ecto.Changeset.t}
+  @callback insert(Ecto.Changeset.t, query_options) ::
+              {:ok, struct} | {:error, :ownership} | {:error, :timeout} | {:error, Ecto.Changeset.t}
 
   @doc """
   Inserts `params` into a single new `struct`
@@ -100,10 +106,12 @@ defmodule Calcinator.Resources do
 
     * `{:ok, struct}` - params were inserted into `struct`
     * `{:error, :ownership}` - connection to backing store was not owned by the calling process
+    * `{:error, :timeout}` - timeout occured while inserting params into backing store.
     * `{:error, Ecto.Changeset.t}` - insert failed.  `Ecto.Changeset.t` `errors` contain errors.
 
   """
-  @callback insert(params, query_options) :: {:ok, struct} | {:error, :ownership} | {:error, Ecto.Changeset.t}
+  @callback insert(params, query_options) ::
+              {:ok, struct} | {:error, :ownership} | {:error, :timeout} | {:error, Ecto.Changeset.t}
 
   @doc """
   Gets a list of `struct`s.
@@ -113,7 +121,7 @@ defmodule Calcinator.Resources do
     * `{:ok, [resource], nil}` - all resources matching query
     * `{:ok, [resource], pagination}` - page of resources matching query
     * `{:error, :ownership}` - connection to backing store was not owned by the calling process
-    * `{:error, :timeout}` - timeout occured while getting resources from backing store .
+    * `{:error, :timeout}` - timeout occured while getting resources from backing store.
     * `{:error, reason}` - an error occurred with the backing store for `reason` that is backing store specific.
 
   """
@@ -139,15 +147,17 @@ defmodule Calcinator.Resources do
     * `{:error, Ecto.Changeset.t}` - errors while updating `struct` with `params`.  `Ecto.Changeset.t` `errors` contains
       errors.
     * `{:error, :bad_gateway}` - error in backing store that cannot be represented as another type of error
-    * `{:error, :ownership}` - connection to backing store was not owned by the calling process
     * `{:error, :not_found}` - the resource in the changeset was not found and so cannot be updated.  This may mean that
       the resource was deleted with `delete/1` after the `get/2` or `list/1` returned.
+    * `{:error, :ownership}` - connection to backing store was not owned by the calling process
+    * `{:error, :timeout}` - timeout occured while updating `resource` with `params` in backing store.
   """
   @callback update(resource :: Ecto.Schema.t, params, query_options) :: {:ok, struct} |
                                                                         {:error, Ecto.Changeset.t} |
                                                                         {:error, :bad_gateway} |
+                                                                        {:error, :not_found} |
                                                                         {:error, :ownership} |
-                                                                        {:error, :not_found}
+                                                                        {:error, :timeout}
 
   @doc """
   Applies updates in `changeset`
@@ -156,10 +166,12 @@ defmodule Calcinator.Resources do
 
     * `{:ok, struct}` - the update succeeded and the returned `struct` contains the updates
     * `{:error, :ownership}` - connection to backing store was not owned by the calling process
+    * `{:error, :timeout}` - timeout occured while updating `changeset` with `params` in backing store.
     * `{:error, Ecto.Changeset.t}` - errors while updating `struct` with `params`.  `Ecto.Changeset.t` `errors` contains
       errors.
   """
-  @callback update(Ecto.Changeset.t, query_options) :: {:ok, struct} | {:error, :ownership} | {:error, Ecto.Changeset.t}
+  @callback update(changeset :: Ecto.Changeset.t, query_options) ::
+              {:ok, struct} | {:error, :ownership} | {:error, :timeout} | {:error, Ecto.Changeset.t}
 
   # Functions
 

--- a/lib/calcinator/resources.ex
+++ b/lib/calcinator/resources.ex
@@ -60,7 +60,7 @@ defmodule Calcinator.Resources do
   @doc """
   Deletes a single `struct`
 
-  # Returns
+  ## Returns
 
     * `{:ok, struct}` - the delete succeeded and the returned struct is the state before delete
     * `{:error, :ownership}` - connection to backing store was not owned by the calling process
@@ -72,7 +72,7 @@ defmodule Calcinator.Resources do
   @doc """
   Gets a single `struct`
 
-  # Returns
+  ## Returns
 
     * `{:ok, struct}` - `id` was found.
     * `{:error, :not_found}` - `id` was not found.
@@ -88,35 +88,36 @@ defmodule Calcinator.Resources do
                                       {:error, reason :: term}
 
   @doc """
-  Inserts `changeset` into a single new `struct`
+  ## `insert(changeset, query_options)`
 
-  # Returns
+  Inserts `changeset` into a single new `struct`.
+
+  ### Returns
+
     * `{:ok, struct}` - `changeset` was inserted into `struct`
     * `{:error, :ownership}` - connection to backing store was not owned by the calling process
-    * `{:error, :timeout}` - timeout occured while inserting changeset into backing store.
+    * `{:error, :timeout}` - timeout occured while inserting `changeset` into backing store.
     * `{:error, Ecto.Changeset.t}` - insert failed.  `Ecto.Changeset.t` `errors` contain errors.
-  """
-  @callback insert(Ecto.Changeset.t, query_options) ::
-              {:ok, struct} | {:error, :ownership} | {:error, :timeout} | {:error, Ecto.Changeset.t}
 
-  @doc """
-  Inserts `params` into a single new `struct`
+  ## `insert(params, query_options)`
 
-  # Returns
+  Inserts `params` into a single new `struct`.
 
-    * `{:ok, struct}` - params were inserted into `struct`
+  ### Returns
+
+    * `{:ok, struct}` - `params` were inserted into `struct`
     * `{:error, :ownership}` - connection to backing store was not owned by the calling process
-    * `{:error, :timeout}` - timeout occured while inserting params into backing store.
+    * `{:error, :timeout}` - timeout occured while inserting `params` into backing store.
     * `{:error, Ecto.Changeset.t}` - insert failed.  `Ecto.Changeset.t` `errors` contain errors.
 
   """
-  @callback insert(params, query_options) ::
+  @callback insert(changeset :: Ecto.Changeset.t | params, query_options) ::
               {:ok, struct} | {:error, :ownership} | {:error, :timeout} | {:error, Ecto.Changeset.t}
 
   @doc """
   Gets a list of `struct`s.
 
-  # Returns
+  ## Returns
 
     * `{:ok, [resource], nil}` - all resources matching query
     * `{:ok, [resource], pagination}` - page of resources matching query
@@ -139,6 +140,20 @@ defmodule Calcinator.Resources do
   @callback sandboxed?() :: boolean
 
   @doc """
+  Applies updates in `changeset`
+
+  # Returns
+
+    * `{:ok, struct}` - the update succeeded and the returned `struct` contains the updates
+    * `{:error, :ownership}` - connection to backing store was not owned by the calling process
+    * `{:error, :timeout}` - timeout occured while updating `changeset` with `params` in backing store.
+    * `{:error, Ecto.Changeset.t}` - errors while updating `struct` with `params`.  `Ecto.Changeset.t` `errors` contains
+      errors.
+  """
+  @callback update(changeset :: Ecto.Changeset.t, query_options) ::
+              {:ok, struct} | {:error, :ownership} | {:error, :timeout} | {:error, Ecto.Changeset.t}
+
+  @doc """
   Updates `struct`
 
   # Returns
@@ -158,20 +173,6 @@ defmodule Calcinator.Resources do
                                                                         {:error, :not_found} |
                                                                         {:error, :ownership} |
                                                                         {:error, :timeout}
-
-  @doc """
-  Applies updates in `changeset`
-
-  # Returns
-
-    * `{:ok, struct}` - the update succeeded and the returned `struct` contains the updates
-    * `{:error, :ownership}` - connection to backing store was not owned by the calling process
-    * `{:error, :timeout}` - timeout occured while updating `changeset` with `params` in backing store.
-    * `{:error, Ecto.Changeset.t}` - errors while updating `struct` with `params`.  `Ecto.Changeset.t` `errors` contains
-      errors.
-  """
-  @callback update(changeset :: Ecto.Changeset.t, query_options) ::
-              {:ok, struct} | {:error, :ownership} | {:error, :timeout} | {:error, Ecto.Changeset.t}
 
   # Functions
 

--- a/lib/calcinator/resources.ex
+++ b/lib/calcinator/resources.ex
@@ -45,7 +45,7 @@ defmodule Calcinator.Resources do
   @doc """
   Allows access to sandbox for testing
   """
-  @callback allow_sandbox_access(sandbox_access_token) :: :ok | {:already, :owner | :allowed} | :not_found
+  @callback allow_sandbox_access(sandbox_access_token) :: :ok | {:error, :sandbox_access_disallowed}
 
   @doc """
   Changeset for creating a struct from the `params`

--- a/mix.exs
+++ b/mix.exs
@@ -29,7 +29,7 @@ defmodule Calcinator.Mixfile do
       test_coverage: [
         tool: ExCoveralls
       ],
-      version: "2.4.0"
+      version: "3.0.0"
     ]
   end
 


### PR DESCRIPTION
# Changelog
## Enhancements
* Can now return (and is preferred to return instead of a timeout exit) `{:error, :timeout}` from all `Calcinator.Resources` action `@callbacks`.  The following were added:
  * `Calcinator.Resources.delete/2`
  * `Calcinator.Resources.get/2`
  * `Calcinator.Resources.insert/2`
  * `Calcinator.Resources.update/2`
  * `Calcinator.Resources.update/3`  

## Bug Fixes
* Previously, the `Calcinator` actions (`create/2`, `delete/2`, `get_related_resource/3`, `index/3`, `show/2`, `show_relationship/3`, and `update/2`) `@spec` and `@doc` include (hopefully) all the errors they can return now 
  * `{:error, :sandbox_access_disallowed}`
  * `{:error, :sandbox_token_missing}`
  * `{:error, :timeout}`
* `@callback`s with the same name/arity can only have on `@doc`, so the second form of `Calcinator.Resources.insert/2` did not show up.
* Change first level of header to `##` to match style guide for ex_doc in `Calcinator.Resources`.
* Rearrange `Calcinator.Resources.update/2`, so it's before `Calcinator.Resources.update/3` to match doc sorted order.

## Incompatible Changes
* `Calcinator.Resources.allow_sandbox_access/1` must now return `:ok | {:error, :sandbox_access_disallowed}`.  The previous `{:already, :allowed | :owner}` maps to `:ok` while `:not_found` maps to `{:error, :sandbox_access_disallowed}`.
* If you previously had total coverage for all return types from `Calcinator` actions, they now also return `{:error, :sandbox_access_disallowed}` and `{:error, :timeout}`.  Previously, instead of `{:error, :sandbox_access_disallowed}`, `:not_found` may been returned, but that was a bug that leaked an implementation detail from how `DBConnection.Ownership` works, so it was removed.