### PR TITLE
Calcinator.Controller totality of Calcinator

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -27,6 +27,7 @@ test:
     - mkdir -p ${CIRCLE_TEST_REPORTS}/calcinator
     - mv _build/test/lib/calcinator/test-junit-report.xml ${CIRCLE_TEST_REPORTS}/calcinator/
     - mix dialyze
-    - mix docs 2>&1 | tee mix-docs.txt
-    - if grep "Closing unclosed backquotes" mix-docs.txt; then exit 1; fi
+    # ex_doc or earmark is falsely reporting unclosed in everything
+    - mix docs #2>&1 | tee mix-docs.txt
+    #- if grep "Closing unclosed backquotes" mix-docs.txt; then exit 1; fi
     - mix inch.report

--- a/config/test.exs
+++ b/config/test.exs
@@ -11,3 +11,6 @@ config :calcinator,
 # Print only warnings and errors during test
 config :logger,
        level: :warn
+
+config :phoenix, :format_encoders,
+  "json-api": Poison

--- a/coveralls.json
+++ b/coveralls.json
@@ -1,5 +1,5 @@
 {
   "coverage_options": {
-    "minimum_coverage": 23.746
+    "minimum_coverage": 81.214
   }
 }

--- a/lib/calcinator.ex
+++ b/lib/calcinator.ex
@@ -224,7 +224,9 @@ defmodule Calcinator do
     with :ok <- allow_sandbox_access(state, params),
          {:ok, target} <- get(state, params),
          :ok <- can(state, :delete, target),
-         {:ok, _deleted} <- delete_ecto_schema(state, target) do
+         # generate a changeset, so `resources_module` can add constraints
+         {:ok, changeset} <- changeset(state, target, %{}),
+         {:ok, _deleted} <- delete_changeset(state, changeset) do
       :ok
     end
   end
@@ -568,11 +570,13 @@ defmodule Calcinator do
     end
   end
 
-  @spec delete_ecto_schema(t, Ecto.Schema.t) :: {:ok, Ecto.Schema.t} |
-                                                {:error, :ownership} |
-                                                {:error, :timeout} |
-                                                {:error, Ecto.Changeset.t}
-  defp delete_ecto_schema(%__MODULE__{resources_module: resources_module}, schema), do: resources_module.delete(schema)
+  @spec delete_changeset(t, Ecto.Changeset.t) :: {:ok, Ecto.Schema.t} |
+                                                 {:error, :ownership} |
+                                                 {:error, :timeout} |
+                                                 {:error, Ecto.Changeset.t}
+  defp delete_changeset(%__MODULE__{resources_module: resources_module}, changeset) do
+    resources_module.delete(changeset)
+  end
 
   @spec document(params, FromJson.action) :: {:ok, Document.t}  | {:error, Document.t}
   defp document(raw_params, action) do

--- a/lib/calcinator.ex
+++ b/lib/calcinator.ex
@@ -101,8 +101,11 @@ defmodule Calcinator do
     |> status_changeset()
   end
 
-  @spec get(module, params, id_key :: String.t, Resources.query_options) ::
-        {:error, {:not_found, parameter} | :timeout | term} | {:ok, Ecto.Schema.t}
+  @spec get(module, params, id_key :: String.t, Resources.query_options) :: {:ok, Ecto.Schema.t} |
+                                                                            {:error, {:not_found, parameter}} |
+                                                                            {:error, :ownership} |
+                                                                            {:error, :timeout} |
+                                                                            {:error, reason :: term}
   def get(resources_module, params, id_key, query_options) when is_map(query_options) do
     with {:error, :not_found} <- params |> Map.fetch!(id_key) |> resources_module.get(query_options) do
       {:error, {:not_found, id_key}}
@@ -138,6 +141,7 @@ defmodule Calcinator do
 
   ## Returns
 
+    * `{:ok, rendereded}` - rendered view of created resource
     * `{:error, :ownership}` - connection to backing store was not owned by the calling process
     * `{:error, :sandbox_access_disallowed}` - Sandbox token was required and present, but did not have the correct
       information to grant access.
@@ -149,17 +153,16 @@ defmodule Calcinator do
       `can?(subject, :create, %Ecto.Changeset{})` returns `false`
     * `{:error, Alembic.Document.t}` - if `params` is not a valid JSONAPI document
     * `{:error, Ecto.Changeset.t}` - if validations errors inserting `Ecto.Changeset.t`
-    * `{:ok, rendereded}` - rendered view of created resource
 
   """
-  @spec create(t, params) :: {:error, :ownership} |
+  @spec create(t, params) :: {:ok, rendered} |
+                             {:error, :ownership} |
                              {:error, :sandbox_access_disallowed} |
                              {:error, :sandbox_token_missing} |
                              {:error, :timeout} |
                              {:error, :unauthorized} |
                              {:error, Document.t} |
-                             {:error, Ecto.Changeset.t} |
-                             {:ok, rendered}
+                             {:error, Ecto.Changeset.t}
   def create(state = %__MODULE__{
                        ecto_schema_module: ecto_schema_module,
                        subject: subject,
@@ -192,6 +195,7 @@ defmodule Calcinator do
 
   ## Returns
 
+    * `:ok` - resource was successfully deleted
     * `{:error, {:not_found, "id"}}` - The "id" did not correspond to resource in the backing store
     * `{:error, :ownership}` - connection to backing store was not owned by the calling process
     * `{:error, :sandbox_access_disallowed}` - Sandbox token was required and present, but did not have the correct
@@ -201,8 +205,9 @@ defmodule Calcinator do
     * `{:error, :timeout}` - if the backing store for `state` `resources_module` times out when calling
       `Calcinator.Resources.get/2` or `Calcinator.Resources.delete/1`.
     * `{:error, :unauthorized}` - The `state` `subject` is not authorized to delete the resource
+    * `{:error, Alembic.Document.t}` - JSONAPI error document with `params` errors
     * `{:error, Ecto.Changeset.t}` - the deletion failed with the errors in `Ecto.Changeset.t`
-    * `:ok` - resource was successfully deleted
+    * `{:error, reason}` - a backing store-specific error
 
   """
   @spec delete(t, params) :: :ok |
@@ -212,7 +217,9 @@ defmodule Calcinator do
                              {:error, :sandbox_token_missing} |
                              {:error, :timeout} |
                              {:error, :unauthorized} |
-                             {:error, Ecto.Changeset.t}
+                             {:error, Document.t} |
+                             {:error, Ecto.Changeset.t} |
+                             {:error, reason :: term}
   def delete(state = %__MODULE__{}, params) do
     with :ok <- allow_sandbox_access(state, params),
          {:ok, target} <- get(state, params),
@@ -237,6 +244,7 @@ defmodule Calcinator do
 
   ## Returns
 
+    * `{:ok, rendered}` - rendered view of related resource
     * `{:error, {:not_found, id_key}}` - The value of the `id_key` key in `params` did not correspond to a resource in
       the backing store.
     * `{:error, :ownership}` - connection to backing store was not owned by the calling process
@@ -247,16 +255,19 @@ defmodule Calcinator do
     * `{:error, :timeout}` - if the backing store for `state` `resources_module` times out when calling
       `Calcinator.Resources.get/2`.
     * `{:error, :unauthorized}` - if the either the source or related resource cannot be shown
-    * `{:ok, rendered}` - rendered view of related resource
+    * `{:error, Alembic.Document.t}` - JSONAPI error document with `params` errors
+    * `{:error, reason}` - a backing store-specific error
 
   """
-  @spec get_related_resource(t, params, map) :: {:error, {:not_found, parameter}} |
+  @spec get_related_resource(t, params, map) :: {:ok, rendered} |
+                                                {:error, {:not_found, parameter}} |
                                                 {:error, :ownership} |
                                                 {:error, :sandbox_access_disallowed} |
                                                 {:error, :sandbox_token_missing} |
                                                 {:error, :timeout} |
                                                 {:error, :unauthorized} |
-                                                {:ok, rendered}
+                                                {:error, Document.t} |
+                                                {:error, reason :: term}
   def get_related_resource(
         state = %__MODULE__{},
         params,
@@ -281,6 +292,7 @@ defmodule Calcinator do
 
   ## Returns
 
+    * `{:ok, rendered}` - the rendered resources with (optional) pagination in the `"meta"`.
     * `{:error, :ownership}` - connection to backing store was not owned by the calling process
     * `{:error, :sandbox_access_disallowed}` - Sandbox token was required and present, but did not have the correct
       information to grant access.
@@ -290,16 +302,16 @@ defmodule Calcinator do
     * `{:error, :unauthorized}` - if `state` `authorization_module` `can?(subject, :index, ecto_schema_module)` returns
       `false`
     * `{:error, Alembic.Document.t}` - if `params` are not valid JSONAPI.
-    * `{:ok, rendered}` - the rendered resources with (optional) pagination in the `"meta"`.
 
   """
-  @spec index(t, params, %{required(:base_uri) => URI.t}) :: {:error, :ownership} |
+  @spec index(t, params, %{required(:base_uri) => URI.t}) :: {:ok, rendered} |
+                                                             {:error, :ownership} |
                                                              {:error, :sandbox_access_disallowed} |
                                                              {:error, :sandbox_token_missing} |
                                                              {:error, :timeout} |
                                                              {:error, :unauthorized} |
-                                                             {:error, Document.t} |
-                                                             {:ok, rendered}
+                                                             {:error, Document.t}
+
   def index(state = %__MODULE__{
                       ecto_schema_module: ecto_schema_module,
                       subject: subject,
@@ -335,6 +347,7 @@ defmodule Calcinator do
 
   ## Returns
 
+    * `{:ok, rendered}` - rendered resource
     * `{:error, {:not_found, "id"}}` - The "id" did not correspond to resource in the backing store
     * `{:error, :ownership}` - connection to backing store was not owned by the calling process
     * `{:error, :sandbox_access_disallowed}` - Sandbox token was required and present, but did not have the correct
@@ -345,17 +358,18 @@ defmodule Calcinator do
       `Calcinator.Resources.get/2`.
     * `{:error, :unauthorized}` - `state` `authorization_module` `can?(subject, :show, got)` returns `false`
     * `{:error, Alembic.Document.t}` - `params` is not valid JSONAPI
-    * `{:ok, rendered}` - rendered resource
+    * `{:error, reason}` - a backing store-specific error
 
   """
-  @spec show(t, params) :: {:error, {:not_found, parameter}} |
+  @spec show(t, params) :: {:ok, rendered} |
+                           {:error, {:not_found, parameter}} |
                            {:error, :ownership} |
                            {:error, :sandbox_access_disallowed} |
                            {:error, :sandbox_token_missing} |
                            {:error, :timeout} |
                            {:error, :unauthorized} |
                            {:error, Document.t} |
-                           {:ok, rendered}
+                           {:error, reason :: term}
   def show(state = %__MODULE__{subject: subject, view_module: view_module}, params = %{"id" => _}) do
     with :ok <- allow_sandbox_access(state, params),
          {:ok, shown} <- get(state, params),
@@ -379,6 +393,7 @@ defmodule Calcinator do
 
   ## Returns
 
+    * `{:ok, rendered}` - rendered view of relationship
     * `{:error, {:not_found, id_key}}` - The value of the `id_key` key in `params` did not correspond to a resource in
       the backing store.
     * `{:error, :ownership}` - connection to backing store was not owned by the calling process
@@ -389,16 +404,19 @@ defmodule Calcinator do
     * `{:error, :timeout}` - if the backing store for `state` `resources_module` times out when calling
       `Calcinator.Resources.get/2`.
     * `{:error, :unauthorized}` - if the either the source or related resource cannot be shown
-    * `{:ok, rendered}` - rendered view of relationship
+    * `{:error, Alembic.Document.t}` - JSONAPI error document with `params` errors
+    * `{:error, reason}` - a backing store-specific error
 
   """
-  @spec show_relationship(t, params, map) :: {:error, {:not_found, parameter}} |
+  @spec show_relationship(t, params, map) :: {:ok, rendered} |
+                                             {:error, {:not_found, parameter}} |
                                              {:error, :ownership} |
                                              {:error, :sandbox_access_disallowed} |
                                              {:error, :sandbox_token_missing} |
                                              {:error, :timeout} |
                                              {:error, :unauthorized} |
-                                             {:ok, rendered}
+                                             {:error, Document.t} |
+                                             {:error, reason :: term}
   def show_relationship(
         state = %__MODULE__{},
         params,
@@ -422,6 +440,7 @@ defmodule Calcinator do
 
   ## Returns
 
+    * `{:ok, rendered}` - the rendered updated resource
     * `{:error, :bad_gateway}` - backing store as internal error that can't be represented in any other format.
       Try again later or call support.
     * `{:error, {:not_found, "id"}}` - get failed or update failed because the resource was deleted between the get and
@@ -436,10 +455,11 @@ defmodule Calcinator do
     * `{:error, :unauthorized}` - the resource either can't be shown or can't be updated
     * `{:error, Alembic.Document.t}` - the `params` are not valid JSONAPI
     * `{:error, Ecto.Changeset.t}` - validations error when updating
-    * `{:ok, rendered}` - the rendered updated resource
+    * `{:error, reason}` - a backing store-specific error
 
   """
-  @spec update(t, params) :: {:error, :bad_gateway} |
+  @spec update(t, params) :: {:ok, rendered} |
+                             {:error, :bad_gateway} |
                              {:error, {:not_found, parameter}} |
                              {:error, :ownership} |
                              {:error, :sandbox_access_disallowed} |
@@ -447,7 +467,7 @@ defmodule Calcinator do
                              {:error, :unauthorized} |
                              {:error, Document.t} |
                              {:error, Ecto.Changeset.t} |
-                             {:ok, rendered}
+                             {:error, reason :: term}
   def update(state = %__MODULE__{subject: subject, view_module: view_module}, params) do
     with :ok <- allow_sandbox_access(state, params),
          {:ok, updatable} <- get(state, params),
@@ -534,8 +554,10 @@ defmodule Calcinator do
   end
 
   @spec create_changeset(t, Ecto.Changeset.t, params) :: {:ok, struct} |
+                                                         {:error, :ownership} |
                                                          {:error, :sandbox_access_disallowed} |
                                                          {:error, :sandbox_token_missing} |
+                                                         {:error, :timeout} |
                                                          {:error, Document.t} |
                                                          {:error, Ecto.Changeset.t}
   defp create_changeset(state = %__MODULE__{resources_module: resources_module}, changeset = %Ecto.Changeset{}, params)
@@ -546,7 +568,10 @@ defmodule Calcinator do
     end
   end
 
-  @spec delete_ecto_schema(t, Ecto.Schema.t) :: {:ok, Ecto.Schema.t} | {:error, Ecto.Changeset.t}
+  @spec delete_ecto_schema(t, Ecto.Schema.t) :: {:ok, Ecto.Schema.t} |
+                                                {:error, :ownership} |
+                                                {:error, :timeout} |
+                                                {:error, Ecto.Changeset.t}
   defp delete_ecto_schema(%__MODULE__{resources_module: resources_module}, schema), do: resources_module.delete(schema)
 
   @spec document(params, FromJson.action) :: {:ok, Document.t}  | {:error, Document.t}
@@ -565,7 +590,12 @@ defmodule Calcinator do
     )
   end
 
-  @spec get(t, params) :: {:error, {:not_found, parameter}} | {:error, Document.t} | {:ok, Ecto.Schema.t}
+  @spec get(t, params) :: {:ok, Ecto.Schema.t} |
+                          {:error, {:not_found, parameter}} |
+                          {:error, :ownership} |
+                          {:error, :timeout} |
+                          {:error, Document.t} |
+                          {:error, reason :: term}
   defp get(state = %__MODULE__{resources_module: resources_module}, params) do
     with {:ok, query_options} <- params_to_query_options(state, params) do
       get(resources_module, params, "id", query_options)
@@ -573,7 +603,7 @@ defmodule Calcinator do
   end
 
   @spec get_maybe_authorized_related(t, Ecto.Schema.t, atom) ::
-        {:error, :unauthorized} | {:ok, nil} | {:ok, Ecto.Schema.t} | no_return
+          {:ok, nil} | {:ok, Ecto.Schema.t} | {:error, :unauthorized}
   defp get_maybe_authorized_related(state, source, association) do
     case get_related(source, association) do
       nil ->
@@ -601,7 +631,12 @@ defmodule Calcinator do
                    %{
                      required(:association) => association,
                      required(:id_key) => String.t,
-                   }) :: {:error, {:not_found, parameter} | :timeout | term} | {:ok, Ecto.Schema.t}
+                   }) :: {:ok, Ecto.Schema.t} |
+                         {:error, {:not_found, parameter}} |
+                         {:error, :ownership} |
+                         {:error, :timeout} |
+                         {:error, Document.t} |
+                         {:error, term}
   defp get_source(%{resources_module: resources_module},
                   params,
                   %{association: association, id_key: id_key}) do
@@ -641,11 +676,15 @@ defmodule Calcinator do
     end
   end
 
-  @spec related_property(t, params, map) :: {:error, {:not_found, parameter}} |
+  @spec related_property(t, params, map) :: {:ok, rendered} |
+                                            {:error, {:not_found, parameter}} |
+                                            {:error, :ownership} |
                                             {:error, :sandbox_access_disallowed} |
                                             {:error, :sandbox_token_missing} |
+                                            {:error, :timeout} |
                                             {:error, :unauthorized} |
-                                            {:ok, rendered}
+                                            {:error, Document.t} |
+                                            {:error, term}
   defp related_property(
         state = %__MODULE__{subject: subject, view_module: view_module},
         params,

--- a/lib/calcinator.ex
+++ b/lib/calcinator.ex
@@ -77,8 +77,14 @@ defmodule Calcinator do
   def authorized(%__MODULE__{}, nil), do: nil
 
   # Filters `struct` or list of `struct`s to only those that can be shown
-  @spec authorized(t, resource :: struct) :: struct
+  @spec authorized(t, unfiltered :: struct) :: struct
   def authorized(%__MODULE__{authorization_module: authorization_module, subject: subject}, unfiltered = %_{}) do
+    authorization_module.filter_associations_can(unfiltered, subject, :show)
+  end
+
+  @spec authorized(t, unfiltered :: [struct]) :: [struct]
+  def authorized(%__MODULE__{authorization_module: authorization_module, subject: subject}, unfiltered)
+      when is_list(unfiltered) do
     authorization_module.filter_associations_can(unfiltered, subject, :show)
   end
 

--- a/lib/calcinator/controller.ex
+++ b/lib/calcinator/controller.ex
@@ -198,6 +198,14 @@ if Code.ensure_loaded?(Phoenix.Controller) do
           |> put_status(:created)
           |> put_resp_content_type("application/vnd.api+json")
           |> send_resp(:created, Poison.encode!(rendered))
+        {:error, :ownership} ->
+          ownership_error(conn)
+        {:error, :sandbox_access_disallowed} ->
+          sandbox_access_disallowed(conn)
+        {:error, :sandbox_token_missing} ->
+          sandbox_token_missing(conn)
+        {:error, :timeout} ->
+          gateway_timeout(conn)
         {:error, :unauthorized} ->
           forbidden(conn)
         {:error, changeset = %Ecto.Changeset{}} ->
@@ -216,8 +224,22 @@ if Code.ensure_loaded?(Phoenix.Controller) do
           |> send_resp(:no_content, "")
         {:error, {:not_found, parameter}} ->
           not_found(conn, parameter)
+        {:error, :ownership} ->
+          ownership_error(conn)
+        {:error, :sandbox_access_disallowed} ->
+          sandbox_access_disallowed(conn)
+        {:error, :sandbox_token_missing} ->
+          sandbox_token_missing(conn)
+        {:error, :timeout} ->
+          gateway_timeout(conn)
         {:error, :unauthorized} ->
           forbidden(conn)
+        {:error, document = %Document{}} ->
+          render_json(conn, document, :unprocessable_entity)
+        {:error, changeset = %Ecto.Changeset{}} ->
+          render_changeset_error(conn, changeset)
+        {:error, reason} ->
+          render_error_reason(conn, reason)
       end
     end
 
@@ -269,8 +291,18 @@ if Code.ensure_loaded?(Phoenix.Controller) do
           |> send_resp(:ok, Poison.encode!(rendered))
         {:error, {:not_found, parameter}} ->
           not_found(conn, parameter)
+        {:error, :ownership} ->
+          ownership_error(conn)
+        {:error, :sandbox_access_disallowed} ->
+          sandbox_access_disallowed(conn)
+        {:error, :sandbox_token_missing} ->
+          sandbox_token_missing(conn)
+        {:error, :timeout} ->
+          gateway_timeout(conn)
         {:error, :unauthorized} ->
           forbidden(conn)
+        {:error, reason} ->
+          render_error_reason(conn, reason)
       end
     end
 
@@ -284,10 +316,18 @@ if Code.ensure_loaded?(Phoenix.Controller) do
           |> put_status(:ok)
           |> put_resp_content_type("application/vnd.api+json")
           |> send_resp(:ok, Poison.encode!(rendered))
+        {:error, :ownership} ->
+          ownership_error(conn)
+        {:error, :sandbox_access_disallowed} ->
+          sandbox_access_disallowed(conn)
+        {:error, :sandbox_token_missing} ->
+          sandbox_token_missing(conn)
+        {:error, :timeout} ->
+          gateway_timeout(conn)
         {:error, :unauthorized} ->
           forbidden(conn)
         {:error, document = %Document{}} ->
-           render_json(conn, document, :unprocessable_entity)
+          render_json(conn, document, :unprocessable_entity)
       end
     end
 
@@ -301,10 +341,20 @@ if Code.ensure_loaded?(Phoenix.Controller) do
            |> send_resp(:ok, Poison.encode!(rendered))
          {:error, {:not_found, parameter}} ->
            not_found(conn, parameter)
+         {:error, :ownership} ->
+           ownership_error(conn)
+         {:error, :sandbox_access_disallowed} ->
+           sandbox_access_disallowed(conn)
+         {:error, :sandbox_token_missing} ->
+           sandbox_token_missing(conn)
+         {:error, :timeout} ->
+           gateway_timeout(conn)
          {:error, :unauthorized} ->
            forbidden(conn)
          {:error, document = %Document{}} ->
            render_json(conn, document, :unprocessable_entity)
+         {:error, reason} ->
+           render_error_reason(conn, reason)
        end
     end
 
@@ -350,8 +400,18 @@ if Code.ensure_loaded?(Phoenix.Controller) do
           |> send_resp(:ok, Poison.encode!(rendered))
         {:error, {:not_found, parameter}} ->
           not_found(conn, parameter)
+        {:error, :ownership} ->
+          ownership_error(conn)
+        {:error, :sandbox_access_disallowed} ->
+          sandbox_access_disallowed(conn)
+        {:error, :sandbox_token_missing} ->
+          sandbox_token_missing(conn)
+        {:error, :timeout} ->
+          gateway_timeout(conn)
         {:error, :unauthorized} ->
           forbidden(conn)
+         {:error, reason} ->
+          render_error_reason(conn, reason)
       end
     end
 
@@ -367,12 +427,22 @@ if Code.ensure_loaded?(Phoenix.Controller) do
            bad_gateway(conn)
          {:error, {:not_found, parameter}} ->
            not_found(conn, parameter)
+         {:error, :ownership} ->
+           ownership_error(conn)
+         {:error, :sandbox_access_disallowed} ->
+           sandbox_access_disallowed(conn)
+         {:error, :sandbox_token_missing} ->
+           sandbox_token_missing(conn)
+         {:error, :timeout} ->
+           gateway_timeout(conn)
          {:error, :unauthorized} ->
            forbidden(conn)
          {:error, changeset = %Ecto.Changeset{}} ->
            render_changeset_error(conn, changeset)
          {:error, document = %Document{}} ->
            render_json(conn, document, :unprocessable_entity)
+         {:error, reason} ->
+           render_error_reason(conn, reason)
        end
     end
 

--- a/lib/calcinator/controller.ex
+++ b/lib/calcinator/controller.ex
@@ -272,31 +272,12 @@ if Code.ensure_loaded?(Phoenix.Controller) do
           params,
           calcinator = %Calcinator{}
         ) do
-      case Calcinator.get_related_resource(
-             %Calcinator{calcinator | subject: get_subject(conn)},
-             params,
-             %{
-               related: related,
-               source: source
-             }
-           ) do
-        {:ok, rendered} ->
-          render_json(conn, rendered, :ok)
-        {:error, {:not_found, parameter}} ->
-          not_found(conn, parameter)
-        {:error, :ownership} ->
-          ownership_error(conn)
-        {:error, :sandbox_access_disallowed} ->
-          sandbox_access_disallowed(conn)
-        {:error, :sandbox_token_missing} ->
-          sandbox_token_missing(conn)
-        {:error, :timeout} ->
-          gateway_timeout(conn)
-        {:error, :unauthorized} ->
-          forbidden(conn)
-        {:error, reason} ->
-          render_error_reason(conn, reason)
-      end
+      %Calcinator{calcinator | subject: get_subject(conn)}
+      |> Calcinator.get_related_resource(
+           params,
+           %{related: related, source: source}
+         )
+      |> respond_to_related_property(conn)
     end
 
     @spec index(Conn.t, Calcinator.params, Calcinator.t) :: Conn.t
@@ -382,28 +363,12 @@ if Code.ensure_loaded?(Phoenix.Controller) do
           params,
           calcinator = %Calcinator{}
         ) do
-      case Calcinator.show_relationship(
-             %Calcinator{calcinator | subject: get_subject(conn)},
-             params,
-             %{related: related, source: source}
-           ) do
-        {:ok, rendered} ->
-          render_json(conn, rendered, :ok)
-        {:error, {:not_found, parameter}} ->
-          not_found(conn, parameter)
-        {:error, :ownership} ->
-          ownership_error(conn)
-        {:error, :sandbox_access_disallowed} ->
-          sandbox_access_disallowed(conn)
-        {:error, :sandbox_token_missing} ->
-          sandbox_token_missing(conn)
-        {:error, :timeout} ->
-          gateway_timeout(conn)
-        {:error, :unauthorized} ->
-          forbidden(conn)
-         {:error, reason} ->
-          render_error_reason(conn, reason)
-      end
+      %Calcinator{calcinator | subject: get_subject(conn)}
+      |> Calcinator.show_relationship(
+           params,
+           %{related: related, source: source}
+         )
+      |> respond_to_related_property(conn)
     end
 
     @spec update(Conn.t, Calcinator.params, Calcinator.t) :: Conn.t
@@ -437,6 +402,27 @@ if Code.ensure_loaded?(Phoenix.Controller) do
     ## Private Functions
 
     defp base_uri(%Conn{request_path: path}), do: %URI{path: path}
+
+    defp respond_to_related_property(related_property_return, conn) do
+      case related_property_return do
+        {:ok, rendered} ->
+          render_json(conn, rendered, :ok)
+        {:error, {:not_found, parameter}} ->
+          not_found(conn, parameter)
+        {:error, :ownership} ->
+          ownership_error(conn)
+        {:error, :sandbox_access_disallowed} ->
+          sandbox_access_disallowed(conn)
+        {:error, :sandbox_token_missing} ->
+          sandbox_token_missing(conn)
+        {:error, :timeout} ->
+          gateway_timeout(conn)
+        {:error, :unauthorized} ->
+          forbidden(conn)
+         {:error, reason} ->
+          render_error_reason(conn, reason)
+      end
+    end
 
     defp quoted_action(quoted_name, quoted_configuration) do
       quote do

--- a/lib/calcinator/controller.ex
+++ b/lib/calcinator/controller.ex
@@ -194,10 +194,7 @@ if Code.ensure_loaded?(Phoenix.Controller) do
     def create(conn = %Conn{}, params, calcinator = %Calcinator{}) do
       case Calcinator.create(%Calcinator{calcinator | subject: get_subject(conn)}, params) do
         {:ok, rendered} ->
-          conn
-          |> put_status(:created)
-          |> put_resp_content_type("application/vnd.api+json")
-          |> send_resp(:created, Poison.encode!(rendered))
+          render_json(conn, rendered, :created)
         {:error, :ownership} ->
           ownership_error(conn)
         {:error, :sandbox_access_disallowed} ->
@@ -219,9 +216,7 @@ if Code.ensure_loaded?(Phoenix.Controller) do
     def delete(conn, params = %{"id" => _}, calcinator = %Calcinator{}) do
       case Calcinator.delete(%Calcinator{calcinator | subject: get_subject(conn)}, params) do
         :ok ->
-          conn
-          |> put_resp_content_type("application/vnd.api+json")
-          |> send_resp(:no_content, "")
+          deleted(conn)
         {:error, {:not_found, parameter}} ->
           not_found(conn, parameter)
         {:error, :ownership} ->
@@ -286,10 +281,7 @@ if Code.ensure_loaded?(Phoenix.Controller) do
              }
            ) do
         {:ok, rendered} ->
-          conn
-          |> put_status(:ok)
-          |> put_resp_content_type("application/vnd.api+json")
-          |> send_resp(:ok, Poison.encode!(rendered))
+          render_json(conn, rendered, :ok)
         {:error, {:not_found, parameter}} ->
           not_found(conn, parameter)
         {:error, :ownership} ->
@@ -313,10 +305,7 @@ if Code.ensure_loaded?(Phoenix.Controller) do
                             params,
                             %{base_uri: base_uri(conn)}) do
         {:ok, rendered} ->
-          conn
-          |> put_status(:ok)
-          |> put_resp_content_type("application/vnd.api+json")
-          |> send_resp(:ok, Poison.encode!(rendered))
+          render_json(conn, rendered, :ok)
         {:error, :ownership} ->
           ownership_error(conn)
         {:error, :sandbox_access_disallowed} ->
@@ -336,10 +325,7 @@ if Code.ensure_loaded?(Phoenix.Controller) do
     def show(conn, params = %{"id" => _}, calcinator = %Calcinator{}) do
        case Calcinator.show(%Calcinator{calcinator | subject: get_subject(conn)}, params) do
          {:ok, rendered} ->
-           conn
-           |> put_status(:ok)
-           |> put_resp_content_type("application/vnd.api+json")
-           |> send_resp(:ok, Poison.encode!(rendered))
+          render_json(conn, rendered, :ok)
          {:error, {:not_found, parameter}} ->
            not_found(conn, parameter)
          {:error, :ownership} ->
@@ -402,10 +388,7 @@ if Code.ensure_loaded?(Phoenix.Controller) do
              %{related: related, source: source}
            ) do
         {:ok, rendered} ->
-          conn
-          |> put_status(:ok)
-          |> put_resp_content_type("application/vnd.api+json")
-          |> send_resp(:ok, Poison.encode!(rendered))
+          render_json(conn, rendered, :ok)
         {:error, {:not_found, parameter}} ->
           not_found(conn, parameter)
         {:error, :ownership} ->
@@ -427,10 +410,7 @@ if Code.ensure_loaded?(Phoenix.Controller) do
     def update(conn, params, calcinator = %Calcinator{}) do
        case Calcinator.update(%Calcinator{calcinator | subject: get_subject(conn)}, params) do
          {:ok, rendered} ->
-           conn
-           |> put_status(:ok)
-           |> put_resp_content_type("application/vnd.api+json")
-           |> send_resp(:ok, Poison.encode!(rendered))
+           render_json(conn, rendered, :ok)
          {:error, :bad_gateway} ->
            bad_gateway(conn)
          {:error, {:not_found, parameter}} ->

--- a/lib/calcinator/controller.ex
+++ b/lib/calcinator/controller.ex
@@ -249,6 +249,7 @@ if Code.ensure_loaded?(Phoenix.Controller) do
     assigns.
 
         resources "/posts", PostController do
+           # Route will be `/posts/:author_id/author`
            get "/author",
                PostController,
                :get_related_resource,
@@ -364,6 +365,7 @@ if Code.ensure_loaded?(Phoenix.Controller) do
     assigns.
 
         resources "/posts", PostController do
+          # Route will be `/posts/:post_id/relationships/author`
           get "/relationships/author"",
               PostController,
               :show_relationship,

--- a/lib/calcinator/controller.ex
+++ b/lib/calcinator/controller.ex
@@ -258,8 +258,8 @@ if Code.ensure_loaded?(Phoenix.Controller) do
                    view_module: AuthorView
                  },
                  source: %{
-                   association: :credential_source,
-                   id_key: "credential_id"
+                   association: :author,
+                   id_key: "post_id"
                  }
                }
         end

--- a/lib/calcinator/controller.ex
+++ b/lib/calcinator/controller.ex
@@ -369,13 +369,19 @@ if Code.ensure_loaded?(Phoenix.Controller) do
               :show_relationship,
               as: :relationships_author,
               assigns: %{
-                association: :author,
+                related: %{
+                  view_module: AuthorView
+                }
                 source: %{
-                  id_key: "author_id"
+                  association: :author,
+                  id_key: "post_id"
                 }
               }
         end
 
+    For relationships, the related resource is not rendered through it's view, but the `related[:view_module]` is still
+    needed in the `assigns` for the `view_module.type()` of the associated resource since relatinships are composed of
+    the `"type"` and `"id"` of the related resource(s).
     """
     @spec show_relationship(Conn.t, Calcinator.params, Calcinator.t) :: Conn.t
     def show_relationship(

--- a/lib/calcinator/controller/error.ex
+++ b/lib/calcinator/controller/error.ex
@@ -19,19 +19,16 @@ if Code.ensure_loaded?(Phoenix.Controller) do
     """
     @spec bad_gateway(Conn.t) :: Conn.t
     def bad_gateway(conn) do
-      conn
-      |> put_status(:bad_gateway)
-      |> put_resp_content_type("application/vnd.api+json")
-      |> json(
-           %Document{
-             errors: [
-               %Error{
-                 status: "502",
-                 title: "Bad Gateway"
-               }
-             ]
-           }
-         )
+      render_json conn,
+                  %Document{
+                    errors: [
+                      %Error{
+                        status: "502",
+                        title: "Bad Gateway"
+                      }
+                    ]
+                  },
+                  :bad_gateway
     end
 
     @doc """
@@ -39,21 +36,17 @@ if Code.ensure_loaded?(Phoenix.Controller) do
     """
     @spec forbidden(Conn.t) :: Conn.t
     def forbidden(conn) do
-      conn
-      |> put_status(:forbidden)
-      |> put_resp_content_type("application/vnd.api+json")
-      |> json(
-           %Document{
-             errors: [
-               %Error{
-                 detail: "You do not have permission for this resource.",
-                 status: "403",
-                 title: "Forbidden"
-               }
-             ]
-           }
-         )
-      |> halt()
+      render_json conn,
+                  %Document{
+                    errors: [
+                      %Error{
+                        detail: "You do not have permission for this resource.",
+                        status: "403",
+                        title: "Forbidden"
+                      }
+                    ]
+                  },
+                  :forbidden
     end
 
     @doc """
@@ -61,19 +54,16 @@ if Code.ensure_loaded?(Phoenix.Controller) do
     """
     @spec gateway_timeout(Conn.t) :: Conn.t
     def gateway_timeout(conn) do
-      conn
-      |> put_status(:gateway_timeout)
-      |> put_resp_content_type("applicaton/vnd.api+json")
-      |> json(
-           %Document{
-             errors: [
-               %Error{
-                 status: "504",
-                 title: "Gateway Timeout"
-               }
-             ]
-           }
-         )
+      render_json conn,
+                  %Document{
+                    errors: [
+                      %Error{
+                        status: "504",
+                        title: "Gateway Timeout"
+                      }
+                    ]
+                  },
+                  :gateway_timeout
     end
 
     @doc """
@@ -81,23 +71,19 @@ if Code.ensure_loaded?(Phoenix.Controller) do
     """
     @spec not_found(Conn.t, String.t) :: Conn.t
     def not_found(conn, parameter) do
-      conn
-      |> put_status(:not_found)
-      |> put_resp_content_type("application/vnd.api+json")
-      |> json(
-           %Document{
-             errors: [
-               %Error{
-                 source: %Source{
-                   parameter: parameter
-                 },
-                 status: "404",
-                 title: "Resource Not Found"
-               }
-             ]
-           }
-         )
-      |> halt()
+      render_json conn,
+                  %Document{
+                    errors: [
+                      %Error{
+                        source: %Source{
+                          parameter: parameter
+                        },
+                        status: "404",
+                        title: "Resource Not Found"
+                      }
+                    ]
+                  },
+                  :not_found
     end
 
     @doc """
@@ -105,27 +91,23 @@ if Code.ensure_loaded?(Phoenix.Controller) do
     """
     @spec ownership_error(Conn.t) :: Conn.t
     def ownership_error(conn) do
-      conn
-      # DBConnection.OwnershipError raised when the connection was checked out from the pool too long and the lease was
-      # revoked.  This could be a 504 Gateway Timeout, but that pool is inside Elixir and not part of the Database
-      # itself, so keeping as 500 Internal Server Error.  504 Gateway Timeout is also not accurate, because the
-      # "gateway" is responding, it's just saying you can't do it.
-      #
-      # See 5XX section of http://racksburg.com/choosing-an-http-status-code/
-      |> put_status(:internal_server_error)
-      |> put_resp_content_type("application/vnd.api+json")
-      |> json(
-           %Document{
-             errors: [
-               %Error{
-                 detail: "Owner of backing store connection could not be found",
-                 status: "500",
-                 title: "Ownership Error"
-               }
-             ]
-           }
-         )
-      |> halt()
+      render_json conn,
+                   %Document{
+                     errors: [
+                       %Error{
+                         detail: "Owner of backing store connection could not be found",
+                         status: "500",
+                         title: "Ownership Error"
+                       }
+                     ]
+                   },
+                   # DBConnection.OwnershipError raised when the connection was checked out from the pool too long and
+                   # the lease was # revoked.  This could be a 504 Gateway Timeout, but that pool is inside Elixir and
+                   # not part of the Database # itself, so keeping as 500 Internal Server Error.  504 Gateway Timeout is
+                   # also not accurate, because the # "gateway" is responding, it's just saying you can't do it.
+                   #
+                   # See 5XX section of http://racksburg.com/choosing-an-http-status-code/
+                   :internal_server_error
     end
 
     @doc """
@@ -194,23 +176,20 @@ if Code.ensure_loaded?(Phoenix.Controller) do
     """
     @spec sandbox_access_disallowed(Conn.t) :: Conn.t
     def sandbox_access_disallowed(conn) do
-      conn
-      |> put_status(:unprocessable_entity)
-      |> put_resp_content_type("application/vnd.api+json")
-      |> json(
-           %Document{
-             errors: [
-               %Error{
-                 detail: "Information in /meta/beam was not enough to grant access to the sandbox",
-                 source: %Source{
-                   pointer: "/meta/beam"
-                 },
-                 status: "422",
-                 title: "Sandbox Access Disallowed"
-               }
-             ]
-           }
-         )
+      render_json conn,
+                  %Document{
+                    errors: [
+                      %Error{
+                        detail: "Information in /meta/beam was not enough to grant access to the sandbox",
+                        source: %Source{
+                          pointer: "/meta/beam"
+                        },
+                        status: "422",
+                        title: "Sandbox Access Disallowed"
+                      }
+                    ]
+                  },
+                  :unprocessable_entity
     end
 
     @doc """
@@ -218,23 +197,20 @@ if Code.ensure_loaded?(Phoenix.Controller) do
     """
     @spec sandbox_token_missing(Conn.t) :: Conn.t
     def sandbox_token_missing(conn) do
-      conn
-      |> put_status(:unprocessable_entity)
-      |> put_resp_content_type("application/vnd.api+json")
-      |> json(
-           %Document{
-             errors: [
-               Error.missing(
-                 %Error{
-                   source: %Source{
-                     pointer: "/meta"
-                   }
-                 },
-                 "beam"
-               )
-             ]
-           }
-         )
+      render_json conn,
+                  %Document{
+                    errors: [
+                      Error.missing(
+                        %Error{
+                          source: %Source{
+                            pointer: "/meta"
+                          }
+                        },
+                        "beam"
+                      )
+                    ]
+                  },
+                  :unprocessable_entity
     end
   end
 end

--- a/lib/calcinator/controller/error.ex
+++ b/lib/calcinator/controller/error.ex
@@ -121,6 +121,24 @@ if Code.ensure_loaded?(Phoenix.Controller) do
     end
 
     @doc """
+    Converts an `{:error, _}` tuple from `Calcinator` into a JSONAPI document and encodes it as the `conn` response.
+    """
+    def put_calcinator_error(conn, {:error, :bad_gateway}), do: bad_gateway(conn)
+    def put_calcinator_error(conn, {:error, {:not_found, parameter}}), do: not_found(conn, parameter)
+    def put_calcinator_error(conn, {:error, :ownership}), do: ownership_error(conn)
+    def put_calcinator_error(conn, {:error, :sandbox_access_disallowed}), do: sandbox_access_disallowed(conn)
+    def put_calcinator_error(conn, {:error, :sandbox_token_missing}), do: sandbox_token_missing(conn)
+    def put_calcinator_error(conn, {:error, :timeout}), do: gateway_timeout(conn)
+    def put_calcinator_error(conn, {:error, :unauthorized}), do: forbidden(conn)
+    def put_calcinator_error(conn, {:error, document = %Document{}}) do
+      render_json(conn, document, :unprocessable_entity)
+    end
+    def put_calcinator_error(conn, {:error, changeset = %Ecto.Changeset{}}) do
+      render_changeset_error(conn, changeset)
+    end
+    def put_calcinator_error(conn, {:error, reason}), do: render_error_reason(conn, reason)
+
+    @doc """
     Puts JSONAPI Content Type in the Response of the `conn`
     """
     def put_resp_content_type(conn), do: put_resp_content_type(conn, "application/vnd.api+json")

--- a/lib/calcinator/controller/error.ex
+++ b/lib/calcinator/controller/error.ex
@@ -11,7 +11,7 @@ if Code.ensure_loaded?(Phoenix.Controller) do
 
     require Logger
 
-    import Conn, only: [halt: 1, put_resp_content_type: 2, put_status: 2]
+    import Conn, only: [halt: 1, put_resp_content_type: 2, put_status: 2, send_resp: 3]
     import Phoenix.Controller, only: [json: 2, render: 4]
 
     @doc """
@@ -29,6 +29,16 @@ if Code.ensure_loaded?(Phoenix.Controller) do
                     ]
                   },
                   :bad_gateway
+    end
+
+    @doc """
+    The resource was deleted
+    """
+    @spec deleted(Conn.t) :: Conn.t
+    def deleted(conn) do
+      conn
+      |> put_resp_content_type()
+      |> send_resp(:no_content, "")
     end
 
     @doc """
@@ -111,6 +121,11 @@ if Code.ensure_loaded?(Phoenix.Controller) do
     end
 
     @doc """
+    Puts JSONAPI Content Type in the Response of the `conn`
+    """
+    def put_resp_content_type(conn), do: put_resp_content_type(conn, "application/vnd.api+json")
+
+    @doc """
     Converts an error `reason` from that isn't a standard format (such as those from the backing store) to a
     500 Internal Server Error JSONAPI error, but with `id` set to `id` that is also used in `Logger.error`, so that
     `reason`, which should remain private to limit implementation disclosures that could lead to security issues.
@@ -154,7 +169,7 @@ if Code.ensure_loaded?(Phoenix.Controller) do
     def render_changeset_error(conn, changeset) do
       conn
       |> put_status(:unprocessable_entity)
-      |> put_resp_content_type("application/vnd.api+json")
+      |> put_resp_content_type()
       |> render(ChangesetView, "error-object.json", changeset)
       |> halt()
     end
@@ -166,7 +181,7 @@ if Code.ensure_loaded?(Phoenix.Controller) do
     def render_json(conn, encodable, status) do
       conn
       |> put_status(status)
-      |> put_resp_content_type("application/vnd.api+json")
+      |> put_resp_content_type()
       |> json(encodable)
       |> halt()
     end

--- a/lib/calcinator/controller/error.ex
+++ b/lib/calcinator/controller/error.ex
@@ -9,6 +9,8 @@ if Code.ensure_loaded?(Phoenix.Controller) do
     alias Calcinator.ChangesetView
     alias Plug.Conn
 
+    require Logger
+
     import Conn, only: [halt: 1, put_resp_content_type: 2, put_status: 2]
     import Phoenix.Controller, only: [json: 2, render: 4]
 
@@ -55,6 +57,26 @@ if Code.ensure_loaded?(Phoenix.Controller) do
     end
 
     @doc """
+    Puts 504 Gateway Timeout JSONAPI error in `conn`.
+    """
+    @spec gateway_timeout(Conn.t) :: Conn.t
+    def gateway_timeout(conn) do
+      conn
+      |> put_status(:gateway_timeout)
+      |> put_resp_content_type("applicaton/vnd.api+json")
+      |> json(
+           %Document{
+             errors: [
+               %Error{
+                 status: "504",
+                 title: "Gateway Timeout"
+               }
+             ]
+           }
+         )
+    end
+
+    @doc """
     Puts 404 Resource Not Found JSONAPI error in `conn` with `parameter` as the source parameter.
     """
     @spec not_found(Conn.t, String.t) :: Conn.t
@@ -79,6 +101,71 @@ if Code.ensure_loaded?(Phoenix.Controller) do
     end
 
     @doc """
+    Puts 500 Internal Server Error JSONAPI error in `conn` with title `"Ownership Error"`.
+    """
+    @spec ownership_error(Conn.t) :: Conn.t
+    def ownership_error(conn) do
+      conn
+      # DBConnection.OwnershipError raised when the connection was checked out from the pool too long and the lease was
+      # revoked.  This could be a 504 Gateway Timeout, but that pool is inside Elixir and not part of the Database
+      # itself, so keeping as 500 Internal Server Error.  504 Gateway Timeout is also not accurate, because the
+      # "gateway" is responding, it's just saying you can't do it.
+      #
+      # See 5XX section of http://racksburg.com/choosing-an-http-status-code/
+      |> put_status(:internal_server_error)
+      |> put_resp_content_type("application/vnd.api+json")
+      |> json(
+           %Document{
+             errors: [
+               %Error{
+                 detail: "Owner of backing store connection could not be found",
+                 status: "500",
+                 title: "Ownership Error"
+               }
+             ]
+           }
+         )
+      |> halt()
+    end
+
+    @doc """
+    Converts an error `reason` from that isn't a standard format (such as those from the backing store) to a
+    500 Internal Server Error JSONAPI error, but with `id` set to `id` that is also used in `Logger.error`, so that
+    `reason`, which should remain private to limit implementation disclosures that could lead to security issues.
+
+    ## Log Messages
+
+    ```
+    id=UUIDv4 reason=inspect(reason)
+    ```
+
+    ## Returns
+
+      * `Plug.Conn.t` - The `Plug.Conn.t` is halted with `Plug.Conn.halt/1`
+
+    """
+    @spec render_error_reason(Conn.t, reason :: term) :: Conn.t
+    def render_error_reason(conn, reason) do
+      id = UUID.uuid4()
+
+      Logger.error fn ->
+        "id=#{id} reason=#{inspect(reason)}"
+      end
+
+      document = %Document{
+        errors: [
+          %Error{
+            id: id,
+            status: "500",
+            title: "Internal Server Error"
+          }
+        ]
+      }
+
+      render_json(conn, document, :internal_server_error)
+    end
+
+    @doc """
     Renders `changeset` as an error object using the `Calcinator.ChangesetView`.
     """
     @spec render_changeset_error(Conn.t, Ecto.Changeset.t) :: Conn.t
@@ -100,6 +187,54 @@ if Code.ensure_loaded?(Phoenix.Controller) do
       |> put_resp_content_type("application/vnd.api+json")
       |> json(encodable)
       |> halt()
+    end
+
+    @doc """
+    Puts 422 Unprocessable Entity JSONAPI error in `conn` with title `"Sandbox Access Disallowed".
+    """
+    @spec sandbox_access_disallowed(Conn.t) :: Conn.t
+    def sandbox_access_disallowed(conn) do
+      conn
+      |> put_status(:unprocessable_entity)
+      |> put_resp_content_type("application/vnd.api+json")
+      |> json(
+           %Document{
+             errors: [
+               %Error{
+                 detail: "Information in /meta/beam was not enough to grant access to the sandbox",
+                 source: %Source{
+                   pointer: "/meta/beam"
+                 },
+                 status: "422",
+                 title: "Sandbox Access Disallowed"
+               }
+             ]
+           }
+         )
+    end
+
+    @doc """
+    Puts 422 Unrpcessable Entity JSONAPI error in `conn` with title `"Child missing".
+    """
+    @spec sandbox_token_missing(Conn.t) :: Conn.t
+    def sandbox_token_missing(conn) do
+      conn
+      |> put_status(:unprocessable_entity)
+      |> put_resp_content_type("application/vnd.api+json")
+      |> json(
+           %Document{
+             errors: [
+               Error.missing(
+                 %Error{
+                   source: %Source{
+                     pointer: "/meta"
+                   }
+                 },
+                 "beam"
+               )
+             ]
+           }
+         )
     end
   end
 end

--- a/lib/calcinator/ja_serializer/phoenix_view.ex
+++ b/lib/calcinator/ja_serializer/phoenix_view.ex
@@ -36,7 +36,7 @@ defmodule Calcinator.JaSerializer.PhoenixView do
   # Functions
 
   def get_related_resource(phoenix_view_module, data, options = %{related: related, source: source})
-      when is_nil(data) or is_map(data) do
+      when is_list(data) or is_map(data) or is_nil(data) do
     params = Map.get(options, :params, %{})
     subject = Map.get(options, :subject, nil)
     opts = params_to_render_opts(params)

--- a/lib/calcinator/related_view.ex
+++ b/lib/calcinator/related_view.ex
@@ -36,7 +36,7 @@ defmodule Calcinator.RelatedView do
       ) do
     "show.json-api"
     |> related_view_module.render(Map.delete(options, [:related, :source]))
-    |> put_in(["data", "links"], links(options))
+    |> put_links(options)
   end
 
   ## Private Functions
@@ -59,5 +59,17 @@ defmodule Calcinator.RelatedView do
     %{
       self: "#{base_url}/#{relationship}",
     }
+  end
+
+  defp put_links(rendered, options) do
+    case rendered["data"] do
+      # has_many relationship has relationship in top-level "links" since it is the link for collection of resources
+      # has_one with nil data has no object for data, so "links" must go to top-level
+      data when is_list(data) or is_nil(data) ->
+        put_in rendered["links"], links(options)
+      # has_one without nil has an object, so "links" can be added
+      data when is_map(data) ->
+        put_in rendered["data"]["links"], links(options)
+    end
   end
 end

--- a/lib/calcinator/relationship_view.ex
+++ b/lib/calcinator/relationship_view.ex
@@ -28,15 +28,24 @@ defmodule Calcinator.RelationshipView do
          %{
            conn: conn,
            related: %{
+             resource: related_resources,
+             view_module: view_module
+           }
+         }
+       ) when is_list(related_resources) do
+    Enum.map related_resources, &resource_identifier(&1, %{conn: conn, view_module: view_module})
+  end
+
+  defp data(
+         %{
+           conn: conn,
+           related: %{
              resource: related,
              view_module: view_module
            }
          }
        ) do
-    %ResourceIdentifier{
-      type: view_module.type,
-      id: related |> view_module.id(conn) |> to_string
-    }
+    resource_identifier(related, %{conn: conn, view_module: view_module})
   end
 
   defp links(options = %{source: %{association: association}}) do
@@ -46,6 +55,17 @@ defmodule Calcinator.RelationshipView do
     %{
       related: "#{base_url}/#{relationship}",
       self: "#{base_url}/relationships/#{relationship}"
+    }
+  end
+
+  defp resource_identifier(resource, %{conn: conn, view_module: view_module}) do
+    id = resource
+         |> view_module.id(conn)
+         |> to_string()
+
+    %ResourceIdentifier{
+      type: view_module.type(),
+      id: id
     }
   end
 end

--- a/lib/calcinator/resources.ex
+++ b/lib/calcinator/resources.ex
@@ -53,21 +53,25 @@ defmodule Calcinator.Resources do
   @callback changeset(params) :: Ecto.Changeset.t
 
   @doc """
-  Changeset for updating `struct` with `params`
+  * Changeset for updating `resource` with `params`.
+  * Changeset for deleting `resource` (`params` will be an empty map)
   """
   @callback changeset(resource :: Ecto.Schema.t, params) :: Ecto.Changeset.t
 
   @doc """
-  Deletes a single `struct`
+  Deletes a single struct in a `changeset`
 
   ## Returns
 
     * `{:ok, struct}` - the delete succeeded and the returned struct is the state before delete
     * `{:error, :ownership}` - connection to backing store was not owned by the calling process
     * `{:error, :timeout}` - timeout occured while deleting `struct` from backing store.
-    * `{:error, Ecto.Changeset.t}` - errors while deleting the `struct`.  `Ecto.Changeset.t` `errors` contains errors.
+    * `{:error, Ecto.Changeset.t}` - errors while deleting the `changeset`.  `Ecto.Changeset.t` `errors` contains
+      errors.  These will normally be constraint errors or only those validations that can occur in `prepare_changes`
+      callbacks that require `Ecto.Changeset.t` `action` and or `repo` to be set.
   """
-  @callback delete(struct) :: {:ok, struct} | {:error, :ownership} | {:error, :timeout} | {:error, Ecto.Changeset.t}
+  @callback delete(changeset :: Ecto.Changeset.t) ::
+              {:ok, struct} | {:error, :ownership} | {:error, :timeout} | {:error, Ecto.Changeset.t}
 
   @doc """
   Gets a single `struct`

--- a/lib/calcinator/resources/ecto/repo.ex
+++ b/lib/calcinator/resources/ecto/repo.ex
@@ -128,7 +128,7 @@ defmodule Calcinator.Resources.Ecto.Repo do
 
       def changeset(data, params), do: EctoRepoResources.changeset(__MODULE__, data, params)
 
-      def delete(data), do: EctoRepoResources.delete(__MODULE__, data)
+      def delete(changeset), do: EctoRepoResources.delete(__MODULE__, changeset)
 
       @spec get(Resources.id, Resources.query_options) ::
             {:ok, Ecto.Schema.t} | {:error, :not_found} | {:error, :ownership}
@@ -203,13 +203,14 @@ defmodule Calcinator.Resources.Ecto.Repo do
   end
 
   @doc """
-  Deletes `data` from `module`'s `repo/0`
+  Deletes `changeset` from `module`'s `repo/0`
   """
-  @spec delete(module, Ecto.Schema.t) :: {:ok, Ecto.Schema.t} | {:error, :ownership} | {:error, Ecto.Changeset.t}
-  def delete(module, data) do
+  @spec delete(module, changeset :: Ecto.Changeset.t) ::
+        {:ok, Ecto.Schema.t} | {:error, :ownership} | {:error, Ecto.Changeset.t}
+  def delete(module, changeset) do
     repo = module.repo()
 
-    wrap_ownership_error(repo, :delete, [data])
+    wrap_ownership_error(repo, :delete, [changeset])
   end
 
   @doc """

--- a/mix.exs
+++ b/mix.exs
@@ -92,7 +92,9 @@ defmodule Calcinator.Mixfile do
       # Phoenix.Controller is used in Calcinator.Controller.Error
       {:phoenix, "~> 1.0", optional: true},
       # PostgreSQL DB access for Calcinator.Resources.Ecto.Repo.Repo used in tests
-      {:postgrex, "~> 0.13.0", only: :test}
+      {:postgrex, "~> 0.13.0", only: :test},
+      # UUID for `errors` `0` `id` in `Calcinator.Controller.backing_store_error`
+      {:uuid, "~> 1.1", optional: true}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -29,4 +29,5 @@
   "poison": {:hex, :poison, "2.2.0", "4763b69a8a77bd77d26f477d196428b741261a761257ff1cf92753a0d4d24a63", [:mix], [], "hexpm"},
   "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], [], "hexpm"},
   "postgrex": {:hex, :postgrex, "0.13.2", "2b88168fc6a5456a27bfb54ccf0ba4025d274841a7a3af5e5deb1b755d95154e", [:mix], [{:connection, "~> 1.0", [hex: :connection, repo: "hexpm", optional: false]}, {:db_connection, "~> 1.1", [hex: :db_connection, repo: "hexpm", optional: false]}, {:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: false]}], "hexpm"},
-  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], [], "hexpm"}}
+  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], [], "hexpm"},
+  "uuid": {:hex, :uuid, "1.1.7", "007afd58273bc0bc7f849c3bdc763e2f8124e83b957e515368c498b641f7ab69", [:mix], [], "hexpm"}}

--- a/test/calcinator/controller_test.exs
+++ b/test/calcinator/controller_test.exs
@@ -1,5 +1,1477 @@
 defmodule Calcinator.ControllerTest do
+  alias Calcinator.{Authorization.Cant, Meta.Beam, TestAuthorView, TestPostView}
+  alias Calcinator.Resources.{TestAuthor, TestPost}
+  alias Calcinator.Resources.Ecto.Repo.{Factory, TestAuthors, TestPosts}
+  alias Calcinator.Resources.Ecto.Repo.Repo
+  alias Plug.Conn
+
+  import ExUnit.CaptureLog
+  import Plug.Conn, only: [put_req_header: 3]
+  import Phoenix.ConnTest, only: [build_conn: 0, json_response: 2, response: 2]
+
   use ExUnit.Case, async: true
 
+  # Callbacks
+
+  setup do
+    Application.put_env(:calcinator, TestAuthors, [])
+
+    conn = build_conn()
+           |> put_req_header("accept", "application/vnd.api+json")
+           |> put_req_header("content-type", "application/vnd.api+json")
+
+    [conn: conn]
+  end
+
+  # Tests
+
   doctest Calcinator.Controller
+
+  describe "create/3" do
+    test "{:ok, renderer}", %{conn: conn} do
+      conn = Calcinator.Controller.create(
+        conn,
+        %{
+          "data" => %{
+            "type" => "test-authors",
+            "attributes" => %{
+              "name" => "Alice"
+            }
+          },
+          "meta" => checkout_meta()
+        },
+        %Calcinator{ecto_schema_module: TestAuthor, resources_module: TestAuthors, view_module: TestAuthorView}
+      )
+
+      assert %{
+               "data" => %{
+                 "type" => "test-authors",
+                 "attributes" => %{
+                   "name" => "Alice"
+                 }
+               }
+             } = json_response(conn, :created)
+    end
+
+    test "{:error, :sandbox_access_disallowed}", %{conn: conn} do
+      meta = checkout_meta()
+      Ecto.Adapters.SQL.Sandbox.checkin(Repo)
+
+      conn = Calcinator.Controller.create(
+        conn,
+        %{
+          "data" => %{
+            "type" => "test-authors",
+            "attributes" => %{
+              "name" => "Alice"
+            }
+          },
+          "meta" => meta
+        },
+        %Calcinator{ecto_schema_module: TestAuthor, resources_module: TestAuthors, view_module: TestAuthorView}
+      )
+
+      assert_sandox_access_disallowed(conn)
+    end
+
+    test "{:error, :sandbox_token_missing}", %{conn: conn} do
+      conn = Calcinator.Controller.create(
+        conn,
+        %{
+          "data" => %{
+            "type" => "test-authors",
+            "attributes" => %{
+              "name" => "Alice"
+            }
+          }
+        },
+        %Calcinator{ecto_schema_module: TestAuthor, resources_module: TestAuthors, view_module: TestAuthorView}
+      )
+
+      assert_sandbox_token_missing(conn)
+    end
+
+    test "{:error, :timeout}", %{conn: conn} do
+      Application.put_env(:calcinator, TestAuthors, [insert: {:error, :timeout}])
+
+      conn = Calcinator.Controller.create(
+        conn,
+        %{
+          "data" => %{
+            "type" => "test-authors",
+            "attributes" => %{
+              "name" => "Alice"
+            }
+          },
+          "meta" => checkout_meta()
+        },
+        %Calcinator{ecto_schema_module: TestAuthor, resources_module: TestAuthors, view_module: TestAuthorView}
+      )
+
+      assert_timeout(conn)
+    end
+
+    test "{:error, :unauthorized}", %{conn: conn} do
+      conn = Calcinator.Controller.create(
+        conn,
+        %{
+          "data" => %{
+            "type" => "test-authors",
+            "attributes" => %{
+              "name" => "Alice"
+            }
+          },
+          "meta" => checkout_meta()
+        },
+        %Calcinator{
+          authorization_module: Cant,
+          ecto_schema_module: TestAuthor,
+          resources_module: TestAuthors,
+          view_module: TestAuthorView
+        }
+      )
+
+      assert_unauthorized(conn)
+    end
+
+    test "{:error, Alembic.Document.t}", %{conn: conn} do
+      conn = Calcinator.Controller.create(
+        conn,
+        %{
+          "data" => %{
+          },
+          "meta" => checkout_meta(),
+        },
+        %Calcinator{ecto_schema_module: TestAuthor, resources_module: TestAuthors, view_module: TestAuthorView}
+      )
+
+      assert %{"errors" => errors} = json_response(conn, 422)
+      assert length(errors) == 2
+      assert %{
+               "detail" => "`/data/type` is missing",
+               "meta" => %{
+                 "child" => "type"
+               },
+               "source" => %{
+                 "pointer" => "/data"
+               },
+               "status" => "422",
+               "title" => "Child missing"
+             } in errors
+      assert %{
+               "detail" => "`/data/id` is missing",
+               "meta" => %{
+                 "child" => "id"
+               },
+               "source" => %{
+                 "pointer" => "/data"
+               },
+               "status" => "422",
+               "title" => "Child missing"
+             } in errors
+    end
+
+    test "{:error, Ecto.Changeset.t}", %{conn: conn} do
+      conn = Calcinator.Controller.create(
+        conn,
+        %{
+          "data" => %{
+            "type" => "test-authors",
+            "attributes" => %{}
+          },
+          "meta" => checkout_meta()
+        },
+        %Calcinator{ecto_schema_module: TestAuthor, resources_module: TestAuthors, view_module: TestAuthorView}
+      )
+
+      assert %{"errors" => errors} = json_response(conn, 422)
+      assert length(errors) == 1
+      assert %{
+               "detail" => "Name can't be blank",
+               "source" => %{
+                 "pointer" => "/data/attributes/name"
+               },
+               "title" => "can't be blank"
+             } in errors
+    end
+  end
+
+  describe "delete/3" do
+    test ":ok", %{conn: conn} do
+      meta = checkout_meta()
+      %TestAuthor{id: id} = Factory.insert(:test_author)
+
+      conn = Calcinator.Controller.delete(
+        conn,
+        %{
+          "id" => id,
+          "meta" => meta
+        },
+        %Calcinator{ecto_schema_module: TestAuthor, resources_module: TestAuthors, view_module: TestAuthorView}
+      )
+
+      assert response(conn, :no_content) == ""
+    end
+
+    test "{:error, {:not_found, _}}", %{conn: conn} do
+      conn = Calcinator.Controller.delete(
+        conn,
+        %{
+          "id" => -1,
+          "meta" => checkout_meta()
+        },
+        %Calcinator{ecto_schema_module: TestAuthor, resources_module: TestAuthors, view_module: TestAuthorView}
+      )
+
+      assert_not_found(conn, "id")
+    end
+
+    test "{:error, :sandbox_access_disallowed}", %{conn: conn} do
+      meta = checkout_meta()
+      %TestAuthor{id: id} = Factory.insert(:test_author)
+      Ecto.Adapters.SQL.Sandbox.checkin(Repo)
+
+      conn = Calcinator.Controller.delete(
+        conn,
+        %{
+          "id" => id,
+          "meta" => meta
+        },
+        %Calcinator{ecto_schema_module: TestAuthor, resources_module: TestAuthors, view_module: TestAuthorView}
+      )
+
+      assert_sandox_access_disallowed(conn)
+    end
+
+    test "{:error, :sandbox_token_missing}", %{conn: conn} do
+      :ok = Ecto.Adapters.SQL.Sandbox.checkout(Repo)
+      %TestAuthor{id: id} = Factory.insert(:test_author)
+
+      conn = Calcinator.Controller.delete(
+        conn,
+        %{
+          "id" => id
+        },
+        %Calcinator{ecto_schema_module: TestAuthor, resources_module: TestAuthors, view_module: TestAuthorView}
+      )
+
+      assert_sandbox_token_missing(conn)
+    end
+
+    test "{:error, :timeout} from Calcinator.Resources.get/2", %{conn: conn} do
+      Application.put_env(:calcinator, TestAuthors, [get: {:error, :timeout}])
+
+      meta = checkout_meta()
+      %TestAuthor{id: id} = Factory.insert(:test_author)
+
+      conn = Calcinator.Controller.delete(
+        conn,
+        %{
+          "id" => id,
+          "meta" => meta
+        },
+        %Calcinator{ecto_schema_module: TestAuthor, resources_module: TestAuthors, view_module: TestAuthorView}
+      )
+
+      assert_timeout(conn)
+    end
+
+    test "{:error, :timeout} from Calcinator.Resources.delete/1", %{conn: conn} do
+      Application.put_env(:calcinator, TestAuthors, [delete: {:error, :timeout}])
+
+      meta = checkout_meta()
+      %TestAuthor{id: id} = Factory.insert(:test_author)
+
+      conn = Calcinator.Controller.delete(
+        conn,
+        %{
+          "id" => id,
+          "meta" => meta
+        },
+        %Calcinator{ecto_schema_module: TestAuthor, resources_module: TestAuthors, view_module: TestAuthorView}
+      )
+
+      assert_timeout(conn)
+    end
+
+    test "{:error, :unauthorized}", %{conn: conn} do
+      meta = checkout_meta()
+      %TestAuthor{id: id} = Factory.insert(:test_author)
+
+      conn = Calcinator.Controller.delete(
+        conn,
+        %{
+          "id" => id,
+          "meta" => meta
+        },
+        %Calcinator{
+          authorization_module: Cant,
+          ecto_schema_module: TestAuthor,
+          resources_module: TestAuthors,
+          view_module: TestAuthorView
+        }
+      )
+
+      assert_unauthorized(conn)
+    end
+
+    test "{:error, Alembic.Document.t}", %{conn: conn} do
+      meta = checkout_meta()
+      %TestAuthor{id: id} = Factory.insert(:test_author)
+
+      conn = Calcinator.Controller.delete(
+        conn,
+        %{
+          "id" => id,
+          "include" => "post",
+          "meta" => meta
+        },
+        %Calcinator{ecto_schema_module: TestAuthor, resources_module: TestAuthors, view_module: TestAuthorView}
+      )
+
+      assert %{"errors" => errors} = json_response(conn, 422)
+      assert length(errors) == 1
+      assert %{
+               "detail" => "`post` is an unknown relationship path",
+               "meta" => %{
+                 "relationship_path" => "post"
+               },
+               "source" => %{
+                 "parameter" => "include"
+               },
+               "title" => "Unknown relationship path"
+             } in errors
+    end
+
+    test "{:error, Ecto.Changeset.t}", %{conn: conn} do
+      meta = checkout_meta()
+      author = %TestAuthor{id: id} = Factory.insert(:test_author)
+      Factory.insert(:test_post, author: author)
+
+      conn = Calcinator.Controller.delete(
+        conn,
+        %{
+          "id" => id,
+          "meta" => meta
+        },
+        %Calcinator{ecto_schema_module: TestAuthor, resources_module: TestAuthors, view_module: TestAuthorView}
+      )
+
+      assert %{"errors" => errors} = json_response(conn, 422)
+      assert length(errors) == 1
+      assert %{
+               "detail" => "Posts are still associated with this entry",
+               "source" => %{
+                 # This pointer not being under relationships is a known JaSerializer bug
+                 "pointer" => "/data/attributes/posts"
+               },
+               "title" => "are still associated with this entry"
+             } in errors
+    end
+
+    test "{:error, reason}", %{conn: conn} do
+      meta = checkout_meta()
+      %TestAuthor{id: id} = Factory.insert(:test_author)
+
+      assert_error_reason :delete, fn ->
+        Calcinator.Controller.delete(
+          conn,
+          %{
+            "id" => id,
+            "meta" => meta
+          },
+          %Calcinator{ecto_schema_module: TestAuthor, resources_module: TestAuthors, view_module: TestAuthorView}
+        )
+      end
+    end
+  end
+
+  describe "get_related_resource/3" do
+    test "{:ok, rendered} for belongs_to", %{conn: conn} do
+      meta = checkout_meta()
+      %TestPost{author: author = %TestAuthor{}, id: id} = Factory.insert(:test_post)
+
+      # done by route.ex definition of route
+      conn = Conn.assign(conn, :related, %{view_module: TestAuthorView})
+      conn = Conn.assign(conn, :source, %{association: :author, id_key: "post_id"})
+
+      # route like `/posts/:post_id/author`
+      conn = Calcinator.Controller.get_related_resource(
+        conn,
+        %{
+          "post_id" => id,
+          "meta" => meta
+        },
+        %Calcinator{ecto_schema_module: TestPost, resources_module: TestPosts, view_module: TestPostView}
+      )
+
+      assert json_response(conn, :ok) ==
+               %{
+                 "jsonapi" => %{
+                   "version" => "1.0"
+                 },
+                 "data" => %{
+                   "type" => "test-authors",
+                   "id" => to_string(author.id),
+                   "attributes" => %{
+                     "name" => author.name
+                   },
+                   "links" => %{
+                     "self" => "/api/v1/test-posts/#{id}/author"
+                   },
+                   "relationships" => %{
+                     "posts" => %{}
+                   }
+                 }
+               }
+    end
+
+    test "{:ok, rendered} for has_many", %{conn: conn} do
+      meta = checkout_meta()
+      post = %TestPost{author: %TestAuthor{id: author_id}} = Factory.insert(:test_post)
+
+      # done by route.ex definition of route
+      conn = Conn.assign(conn, :related, %{view_module: TestPostView})
+      conn = Conn.assign(conn, :source, %{association: :posts, id_key: "author_id"})
+
+      # route like `/authors/:author_id/posts`
+      conn = Calcinator.Controller.get_related_resource(
+        conn,
+        %{
+          "author_id" => author_id,
+          "meta" => meta
+        },
+        %Calcinator{ecto_schema_module: TestAuthor, resources_module: TestAuthors, view_module: TestAuthorView}
+      )
+
+      assert %{"data" => data, "links" => links} = json_response(conn, :ok)
+
+      assert is_list(data)
+      assert length(data) == 1
+      assert %{
+               "type" => "test-posts",
+               "id" => to_string(post.id),
+               "attributes" => %{
+                 "body" => post.body
+               },
+               "links" => %{
+                 "self" => "/api/v1/test-posts/#{post.id}"
+               }
+             } in data
+
+      assert links == %{"self" => "/api/v1/test-authors/#{author_id}/posts"}
+    end
+
+    test "{:error, {:not_found, _}}", %{conn: conn} do
+      meta = checkout_meta()
+
+      # done by route.ex definition of route
+      conn = Conn.assign(conn, :related, %{view_module: TestAuthorView})
+      conn = Conn.assign(conn, :source, %{association: :author, id_key: "post_id"})
+
+      # route like `/posts/:post_id/author`
+      conn = Calcinator.Controller.get_related_resource(
+        conn,
+        %{
+          "post_id" => -1,
+          "meta" => meta
+        },
+        %Calcinator{ecto_schema_module: TestPost, resources_module: TestPosts, view_module: TestPostView}
+      )
+
+      assert_not_found(conn, "post_id")
+    end
+
+    test "{:error, :sandbox_access_disallowed}", %{conn: conn} do
+      meta = checkout_meta()
+      %TestPost{author: %TestAuthor{}, id: id} = Factory.insert(:test_post)
+      Ecto.Adapters.SQL.Sandbox.checkin(Repo)
+
+      # done by route.ex definition of route
+      conn = Conn.assign(conn, :related, %{view_module: TestAuthorView})
+      conn = Conn.assign(conn, :source, %{association: :author, id_key: "post_id"})
+
+      # route like `/posts/:post_id/author`
+      conn = Calcinator.Controller.get_related_resource(
+        conn,
+        %{
+          "post_id" => id,
+          "meta" => meta
+        },
+        %Calcinator{ecto_schema_module: TestPost, resources_module: TestPosts, view_module: TestPostView}
+      )
+
+      assert_sandox_access_disallowed(conn)
+    end
+
+    test "{:error, :sandbox_token_missing}", %{conn: conn} do
+      :ok = Ecto.Adapters.SQL.Sandbox.checkout(Repo)
+      %TestPost{author: %TestAuthor{}, id: id} = Factory.insert(:test_post)
+
+      # done by route.ex definition of route
+      conn = Conn.assign(conn, :related, %{view_module: TestAuthorView})
+      conn = Conn.assign(conn, :source, %{association: :author, id_key: "post_id"})
+
+      # route like `/posts/:post_id/author`
+      conn = Calcinator.Controller.get_related_resource(
+        conn,
+        %{
+          "post_id" => id
+        },
+        %Calcinator{ecto_schema_module: TestPost, resources_module: TestPosts, view_module: TestPostView}
+      )
+
+      assert_sandbox_token_missing(conn)
+    end
+
+    test "{:error, :timeout}", %{conn: conn} do
+      Application.put_env(:calcinator, TestAuthors, [get: {:error, :timeout}])
+
+      meta = checkout_meta()
+      %TestPost{author: %TestAuthor{id: author_id}} = Factory.insert(:test_post)
+
+      # done by route.ex definition of route
+      conn = Conn.assign(conn, :related, %{view_module: TestPostView})
+      conn = Conn.assign(conn, :source, %{association: :posts, id_key: "author_id"})
+
+      # route like `/authors/:author_id/posts`
+      conn = Calcinator.Controller.get_related_resource(
+        conn,
+        %{
+          "author_id" => author_id,
+          "meta" => meta
+        },
+        %Calcinator{ecto_schema_module: TestAuthor, resources_module: TestAuthors, view_module: TestAuthorView}
+      )
+
+      assert_timeout(conn)
+    end
+
+    test "{:error, :unauthorized}", %{conn: conn} do
+      meta = checkout_meta()
+      %TestPost{author: %TestAuthor{}, id: id} = Factory.insert(:test_post)
+
+      # done by route.ex definition of route
+      conn = Conn.assign(conn, :related, %{view_module: TestAuthorView})
+      conn = Conn.assign(conn, :source, %{association: :author, id_key: "post_id"})
+
+      # route like `/posts/:post_id/author`
+      conn = Calcinator.Controller.get_related_resource(
+        conn,
+        %{
+          "post_id" => id,
+          "meta" => meta
+        },
+        %Calcinator{
+          authorization_module: Cant,
+          ecto_schema_module: TestPost,
+          resources_module: TestPosts,
+          view_module: TestPostView
+        }
+      )
+
+      assert_unauthorized(conn)
+    end
+
+    test "{:error, reason}", %{conn: conn} do
+      meta = checkout_meta()
+      %TestPost{author: %TestAuthor{id: author_id}} = Factory.insert(:test_post)
+
+      # done by route.ex definition of route
+      conn = Conn.assign(conn, :related, %{view_module: TestPostView})
+      conn = Conn.assign(conn, :source, %{association: :posts, id_key: "author_id"})
+
+      assert_error_reason :get, fn ->
+        Calcinator.Controller.get_related_resource(
+          conn,
+          %{
+            "author_id" => author_id,
+            "meta" => meta
+          },
+          %Calcinator{ecto_schema_module: TestAuthor, resources_module: TestAuthors, view_module: TestAuthorView}
+        )
+      end
+    end
+  end
+
+  describe "index/3" do
+    test "{:ok, rendered}", %{conn: conn} do
+      meta = checkout_meta()
+      count = 2
+      test_authors = Factory.insert_list(count, :test_author)
+
+      conn = Calcinator.Controller.index(
+        conn,
+        %{
+          "meta" => meta
+        },
+        %Calcinator{ecto_schema_module: TestAuthor, resources_module: TestAuthors, view_module: TestAuthorView}
+      )
+
+      assert %{"data" => data} = json_response(conn, :ok)
+      assert is_list(data)
+      assert length(data) == count
+
+      Enum.each test_authors, fn test_author ->
+        assert test_author_resource(test_author) in data
+      end
+    end
+
+    test "{:error, :sandbox_access_disallowed}", %{conn: conn} do
+      meta = checkout_meta()
+      count = 2
+      Factory.insert_list(count, :test_author)
+      Ecto.Adapters.SQL.Sandbox.checkin(Repo)
+
+      conn = Calcinator.Controller.index(
+        conn,
+        %{
+          "meta" => meta
+        },
+        %Calcinator{ecto_schema_module: TestAuthor, resources_module: TestAuthors, view_module: TestAuthorView}
+      )
+
+      assert_sandox_access_disallowed(conn)
+    end
+
+    test "{:error, :sandbox_token_missing}", %{conn: conn} do
+      :ok = Ecto.Adapters.SQL.Sandbox.checkout(Repo)
+      count = 2
+      Factory.insert_list(count, :test_author)
+
+      conn = Calcinator.Controller.index(
+        conn,
+        %{},
+        %Calcinator{ecto_schema_module: TestAuthor, resources_module: TestAuthors, view_module: TestAuthorView}
+      )
+
+      assert_sandbox_token_missing(conn)
+    end
+
+    test "{:error, :timeout}", %{conn: conn} do
+      Application.put_env(:calcinator, TestAuthors, [list: {:error, :timeout}])
+      meta = checkout_meta()
+      count = 2
+      Factory.insert_list(count, :test_author)
+
+      conn = Calcinator.Controller.index(
+        conn,
+        %{
+          "meta" => meta
+        },
+        %Calcinator{ecto_schema_module: TestAuthor, resources_module: TestAuthors, view_module: TestAuthorView}
+      )
+
+      assert_timeout(conn)
+    end
+
+    test "{:error, :unauthorized}", %{conn: conn} do
+      meta = checkout_meta()
+      count = 2
+      Factory.insert_list(count, :test_author)
+
+      conn = Calcinator.Controller.index(
+        conn,
+        %{
+          "meta" => meta
+        },
+        %Calcinator{
+          authorization_module: Cant,
+          ecto_schema_module: TestAuthor,
+          resources_module: TestAuthors,
+          view_module: TestAuthorView
+        }
+      )
+
+      assert_unauthorized(conn)
+    end
+
+    test "{:error, Alembic.Document.t}", %{conn: conn} do
+      meta = checkout_meta()
+      count = 2
+      Factory.insert_list(count, :test_author)
+
+      conn = Calcinator.Controller.index(
+        conn,
+        %{
+          "include" => "post",
+          "meta" => meta
+        },
+        %Calcinator{ecto_schema_module: TestAuthor, resources_module: TestAuthors, view_module: TestAuthorView}
+      )
+
+      assert %{"errors" => errors} = json_response(conn, 422)
+      assert length(errors) == 1
+      assert %{
+               "detail" => "`post` is an unknown relationship path",
+               "meta" => %{
+                 "relationship_path" => "post"
+               },
+               "source" => %{
+                 "parameter" => "include"
+               },
+               "title" => "Unknown relationship path"
+             } in errors
+    end
+  end
+
+  describe "show/3" do
+    test "{:ok, rendered}", %{conn: conn} do
+      meta = checkout_meta()
+      test_author = Factory.insert(:test_author)
+
+      conn = Calcinator.Controller.show(
+        conn,
+        %{
+          "id" => test_author.id,
+          "meta" => meta
+        },
+        %Calcinator{ecto_schema_module: TestAuthor, resources_module: TestAuthors, view_module: TestAuthorView}
+      )
+
+      assert %{"data" => data} = json_response(conn, :ok)
+      assert data == test_author_resource(test_author)
+    end
+
+    test "{:error, {:not_found, _}}", %{conn: conn} do
+      meta = checkout_meta()
+
+      conn = Calcinator.Controller.show(
+        conn,
+        %{
+          "id" => -1,
+          "meta" => meta
+        },
+        %Calcinator{ecto_schema_module: TestAuthor, resources_module: TestAuthors, view_module: TestAuthorView}
+      )
+
+      assert_not_found(conn, "id")
+    end
+
+    test "{:error, :sandbox_access_disallowed}", %{conn: conn} do
+      meta = checkout_meta()
+      %TestAuthor{id: id} = Factory.insert(:test_author)
+      Ecto.Adapters.SQL.Sandbox.checkin(Repo)
+
+      conn = Calcinator.Controller.show(
+        conn,
+        %{
+          "id" => id,
+          "meta" => meta
+        },
+        %Calcinator{ecto_schema_module: TestAuthor, resources_module: TestAuthors, view_module: TestAuthorView}
+      )
+
+      assert_sandox_access_disallowed(conn)
+    end
+
+    test "{:error, :sandbox_token_missing}", %{conn: conn} do
+      :ok = Ecto.Adapters.SQL.Sandbox.checkout(Repo)
+      %TestAuthor{id: id} = Factory.insert(:test_author)
+
+      conn = Calcinator.Controller.show(
+        conn,
+        %{
+          "id" => id
+        },
+        %Calcinator{ecto_schema_module: TestAuthor, resources_module: TestAuthors, view_module: TestAuthorView}
+      )
+
+      assert_sandbox_token_missing(conn)
+    end
+
+    test "{:error, :timeout}", %{conn: conn} do
+      Application.put_env(:calcinator, TestAuthors, [get: {:error, :timeout}])
+      meta = checkout_meta()
+      %TestAuthor{id: id} = Factory.insert(:test_author)
+
+      conn = Calcinator.Controller.show(
+        conn,
+        %{
+          "id" => id,
+          "meta" => meta
+        },
+        %Calcinator{ecto_schema_module: TestAuthor, resources_module: TestAuthors, view_module: TestAuthorView}
+      )
+
+      assert_timeout(conn)
+    end
+
+    test "{:error, :unauthorized}", %{conn: conn} do
+      meta = checkout_meta()
+      %TestAuthor{id: id} = Factory.insert(:test_author)
+
+      conn = Calcinator.Controller.show(
+        conn,
+        %{
+          "id" => id,
+          "meta" => meta
+        },
+        %Calcinator{
+          authorization_module: Cant,
+          ecto_schema_module: TestAuthor,
+          resources_module: TestAuthors,
+          view_module: TestAuthorView
+        }
+      )
+
+      assert_unauthorized(conn)
+    end
+
+    test "{:error, Alembic.Document.t}", %{conn: conn} do
+      meta = checkout_meta()
+      %TestAuthor{id: id} = Factory.insert(:test_author)
+
+      conn = Calcinator.Controller.show(
+        conn,
+        %{
+          "id" => id,
+          "include" => "post",
+          "meta" => meta
+        },
+        %Calcinator{ecto_schema_module: TestAuthor, resources_module: TestAuthors, view_module: TestAuthorView}
+      )
+
+      assert %{"errors" => errors} = json_response(conn, 422)
+      assert length(errors) == 1
+      assert %{
+               "detail" => "`post` is an unknown relationship path",
+               "meta" => %{
+                 "relationship_path" => "post"
+               },
+               "source" => %{
+                 "parameter" => "include"
+               },
+               "title" => "Unknown relationship path"
+             } in errors
+    end
+
+    test "{:error, reason}", %{conn: conn} do
+      meta = checkout_meta()
+      %TestAuthor{id: id} = Factory.insert(:test_author)
+
+      assert_error_reason :get, fn ->
+        Calcinator.Controller.show(
+          conn,
+          %{
+            "id" => id,
+            "meta" => meta
+          },
+          %Calcinator{ecto_schema_module: TestAuthor, resources_module: TestAuthors, view_module: TestAuthorView}
+        )
+      end
+    end
+  end
+
+  describe "show_relationship/3" do
+    test "{:ok, rendered} for belongs_to", %{conn: conn} do
+      meta = checkout_meta()
+      %TestPost{author: author = %TestAuthor{}, id: id} = Factory.insert(:test_post)
+
+      # done by route.ex definition of route
+      conn = Conn.assign(conn, :related, %{view_module: TestAuthorView})
+      conn = Conn.assign(conn, :source, %{association: :author, id_key: "post_id"})
+
+      # route like `/posts/:post_id/relationship/author`
+      conn = Calcinator.Controller.show_relationship(
+        conn,
+        %{
+          "post_id" => id,
+          "meta" => meta
+        },
+        %Calcinator{ecto_schema_module: TestPost, resources_module: TestPosts, view_module: TestPostView}
+      )
+
+      assert json_response(conn, :ok) ==
+               %{
+                 "jsonapi" => %{
+                   "version" => "1.0"
+                 },
+                 "data" => %{
+                   "id" => to_string(author.id),
+                   "type" => "test-authors"
+                 },
+                 "links" => %{
+                   "related" => "/api/v1/test-posts/#{id}/author",
+                   "self" => "/api/v1/test-posts/#{id}/relationships/author"
+                 }
+               }
+    end
+
+    test "{:ok, rendered} for has_many", %{conn: conn} do
+      meta = checkout_meta()
+      post = %TestPost{author: %TestAuthor{id: author_id}} = Factory.insert(:test_post)
+
+      # done by route.ex definition of route
+      conn = Conn.assign(conn, :related, %{view_module: TestPostView})
+      conn = Conn.assign(conn, :source, %{association: :posts, id_key: "author_id"})
+
+      # route like `/authors/:author_id/posts`
+      conn = Calcinator.Controller.show_relationship(
+        conn,
+        %{
+          "author_id" => author_id,
+          "meta" => meta
+        },
+        %Calcinator{ecto_schema_module: TestAuthor, resources_module: TestAuthors, view_module: TestAuthorView}
+      )
+
+      assert %{"data" => data, "links" => links} = json_response(conn, :ok)
+
+      assert is_list(data)
+      assert length(data) == 1
+      assert %{
+               "type" => "test-posts",
+               "id" => to_string(post.id)
+             } in data
+
+      assert links == %{
+                        "related" => "/api/v1/test-authors/#{author_id}/posts",
+                        "self" => "/api/v1/test-authors/#{author_id}/relationships/posts"
+                      }
+    end
+
+    test "{:error, {:not_found, _}}", %{conn: conn} do
+      meta = checkout_meta()
+
+      # done by route.ex definition of route
+      conn = Conn.assign(conn, :related, %{view_module: TestAuthorView})
+      conn = Conn.assign(conn, :source, %{association: :author, id_key: "post_id"})
+
+      # route like `/posts/:post_id/author`
+      conn = Calcinator.Controller.show_relationship(
+        conn,
+        %{
+          "post_id" => -1,
+          "meta" => meta
+        },
+        %Calcinator{ecto_schema_module: TestPost, resources_module: TestPosts, view_module: TestPostView}
+      )
+
+      assert_not_found(conn, "post_id")
+    end
+
+    test "{:error, :sandbox_access_disallowed}", %{conn: conn} do
+      meta = checkout_meta()
+      %TestPost{author: %TestAuthor{}, id: id} = Factory.insert(:test_post)
+      Ecto.Adapters.SQL.Sandbox.checkin(Repo)
+
+      # done by route.ex definition of route
+      conn = Conn.assign(conn, :related, %{view_module: TestAuthorView})
+      conn = Conn.assign(conn, :source, %{association: :author, id_key: "post_id"})
+
+      # route like `/posts/:post_id/author`
+      conn = Calcinator.Controller.show_relationship(
+        conn,
+        %{
+          "post_id" => id,
+          "meta" => meta
+        },
+        %Calcinator{ecto_schema_module: TestPost, resources_module: TestPosts, view_module: TestPostView}
+      )
+
+      assert_sandox_access_disallowed(conn)
+    end
+
+    test "{:error, :sandbox_token_missing}", %{conn: conn} do
+      :ok = Ecto.Adapters.SQL.Sandbox.checkout(Repo)
+      %TestPost{author: %TestAuthor{}, id: id} = Factory.insert(:test_post)
+
+      # done by route.ex definition of route
+      conn = Conn.assign(conn, :related, %{view_module: TestAuthorView})
+      conn = Conn.assign(conn, :source, %{association: :author, id_key: "post_id"})
+
+      # route like `/posts/:post_id/author`
+      conn = Calcinator.Controller.show_relationship(
+        conn,
+        %{
+          "post_id" => id
+        },
+        %Calcinator{ecto_schema_module: TestPost, resources_module: TestPosts, view_module: TestPostView}
+      )
+
+      assert_sandbox_token_missing(conn)
+    end
+
+    test "{:error, :timeout}", %{conn: conn} do
+      Application.put_env(:calcinator, TestAuthors, [get: {:error, :timeout}])
+
+      meta = checkout_meta()
+      %TestPost{author: %TestAuthor{id: author_id}} = Factory.insert(:test_post)
+
+      # done by route.ex definition of route
+      conn = Conn.assign(conn, :related, %{view_module: TestPostView})
+      conn = Conn.assign(conn, :source, %{association: :posts, id_key: "author_id"})
+
+      # route like `/authors/:author_id/posts`
+      conn = Calcinator.Controller.show_relationship(
+        conn,
+        %{
+          "author_id" => author_id,
+          "meta" => meta
+        },
+        %Calcinator{ecto_schema_module: TestAuthor, resources_module: TestAuthors, view_module: TestAuthorView}
+      )
+
+      assert_timeout(conn)
+    end
+
+    test "{:error, :unauthorized}", %{conn: conn} do
+      meta = checkout_meta()
+      %TestPost{author: %TestAuthor{}, id: id} = Factory.insert(:test_post)
+
+      # done by route.ex definition of route
+      conn = Conn.assign(conn, :related, %{view_module: TestAuthorView})
+      conn = Conn.assign(conn, :source, %{association: :author, id_key: "post_id"})
+
+      # route like `/posts/:post_id/author`
+      conn = Calcinator.Controller.show_relationship(
+        conn,
+        %{
+          "post_id" => id,
+          "meta" => meta
+        },
+        %Calcinator{
+          authorization_module: Cant,
+          ecto_schema_module: TestPost,
+          resources_module: TestPosts,
+          view_module: TestPostView
+        }
+      )
+
+      assert_unauthorized(conn)
+    end
+
+    test "{:error, reason}", %{conn: conn} do
+      meta = checkout_meta()
+      %TestPost{author: %TestAuthor{id: author_id}} = Factory.insert(:test_post)
+
+      # done by route.ex definition of route
+      conn = Conn.assign(conn, :related, %{view_module: TestPostView})
+      conn = Conn.assign(conn, :source, %{association: :posts, id_key: "author_id"})
+
+      assert_error_reason :get, fn ->
+        Calcinator.Controller.show_relationship(
+          conn,
+          %{
+            "author_id" => author_id,
+            "meta" => meta
+          },
+          %Calcinator{ecto_schema_module: TestAuthor, resources_module: TestAuthors, view_module: TestAuthorView}
+        )
+      end
+    end
+  end
+
+  describe "update/3" do
+    test "{:ok, rendered}", %{conn: conn} do
+      meta = checkout_meta()
+      test_author = %TestAuthor{id: id} = Factory.insert(:test_author, name: "Alice")
+
+      conn = Calcinator.Controller.update(
+        conn,
+        %{
+          "id" => id,
+          "data" => %{
+            "type" => "test-authors",
+            "id" => to_string(id),
+            "attributes" => %{
+              "name" => "Eve"
+            }
+          },
+          "meta" => meta
+        },
+        %Calcinator{ecto_schema_module: TestAuthor, resources_module: TestAuthors, view_module: TestAuthorView}
+      )
+
+      assert %{"data" => data} = json_response(conn, :ok)
+      assert data == test_author_resource(%{test_author | name: "Eve"})
+    end
+
+    # has happened when the `carrot_rpc` servers in Ruby crash with a 500 Internal Server error
+    test "{:error, :bad_gateway}", %{conn: conn} do
+      Application.put_env(:calcinator, TestAuthors, [{:update, {:error, :bad_gateway}}])
+
+      meta = checkout_meta()
+      %TestAuthor{id: id} = Factory.insert(:test_author, name: "Alice")
+
+      conn = Calcinator.Controller.update(
+        conn,
+        %{
+          "id" => id,
+          "data" => %{
+            "type" => "test-authors",
+            "id" => to_string(id),
+            "attributes" => %{
+              "name" => "Eve"
+            }
+          },
+          "meta" => meta
+        },
+        %Calcinator{ecto_schema_module: TestAuthor, resources_module: TestAuthors, view_module: TestAuthorView}
+      )
+
+      assert %{"errors" => errors} = json_response(conn, :bad_gateway)
+      assert is_list(errors)
+      assert length(errors) == 1
+      assert %{
+               "status" => "502",
+               "title" => "Bad Gateway"
+             } in errors
+    end
+
+    test "{:error, {:not_found, _}}", %{conn: conn} do
+      id = -1
+      conn = Calcinator.Controller.update(
+        conn,
+        %{
+          "id" => id,
+          "data" => %{
+            "type" => "test-authors",
+            "id" => to_string(id),
+            "attributes" => %{
+              "name" => "Eve"
+            }
+          },
+          "meta" => checkout_meta()
+        },
+        %Calcinator{ecto_schema_module: TestAuthor, resources_module: TestAuthors, view_module: TestAuthorView}
+      )
+
+      assert_not_found(conn, "id")
+    end
+
+    test "{:error, :sandbox_access_disallowed}", %{conn: conn} do
+      meta = checkout_meta()
+      %TestAuthor{id: id} = Factory.insert(:test_author)
+      Ecto.Adapters.SQL.Sandbox.checkin(Repo)
+
+      conn = Calcinator.Controller.update(
+        conn,
+        %{
+          "id" => id,
+          "data" => %{
+            "type" => "test-authors",
+            "id" => to_string(id),
+            "attributes" => %{
+              "name" => "Eve"
+            }
+          },
+          "meta" => meta
+        },
+        %Calcinator{ecto_schema_module: TestAuthor, resources_module: TestAuthors, view_module: TestAuthorView}
+      )
+
+      assert_sandox_access_disallowed(conn)
+    end
+
+    test "{:error, :sandbox_token_missing}", %{conn: conn} do
+      :ok = Ecto.Adapters.SQL.Sandbox.checkout(Repo)
+      %TestAuthor{id: id} = Factory.insert(:test_author)
+
+      conn = Calcinator.Controller.update(
+        conn,
+        %{
+          "id" => id,
+          "data" => %{
+            "type" => "test-authors",
+            "id" => to_string(id),
+            "attributes" => %{
+              "name" => "Eve"
+            }
+          }
+        },
+        %Calcinator{ecto_schema_module: TestAuthor, resources_module: TestAuthors, view_module: TestAuthorView}
+      )
+
+      assert_sandbox_token_missing(conn)
+    end
+
+    test "{:error, :timeout} from Calcinator.Resources.get/2", %{conn: conn} do
+      Application.put_env(:calcinator, TestAuthors, [get: {:error, :timeout}])
+
+      meta = checkout_meta()
+      %TestAuthor{id: id} = Factory.insert(:test_author)
+
+      conn = Calcinator.Controller.update(
+        conn,
+        %{
+          "id" => id,
+          "data" => %{
+            "type" => "test-authors",
+            "id" => to_string(id),
+            "attributes" => %{
+              "name" => "Eve"
+            }
+          },
+          "meta" => meta
+        },
+        %Calcinator{ecto_schema_module: TestAuthor, resources_module: TestAuthors, view_module: TestAuthorView}
+      )
+
+      assert_timeout(conn)
+    end
+
+    test "{:error, :timeout} from Calcinator.Resources.update/1", %{conn: conn} do
+      Application.put_env(:calcinator, TestAuthors, [update: {:error, :timeout}])
+
+      meta = checkout_meta()
+      %TestAuthor{id: id} = Factory.insert(:test_author)
+
+      conn = Calcinator.Controller.update(
+        conn,
+        %{
+          "id" => id,
+          "data" => %{
+            "type" => "test-authors",
+            "id" => to_string(id),
+            "attributes" => %{
+              "name" => "Eve"
+            }
+          },
+          "meta" => meta
+        },
+        %Calcinator{ecto_schema_module: TestAuthor, resources_module: TestAuthors, view_module: TestAuthorView}
+      )
+
+      assert_timeout(conn)
+    end
+
+    test "{:error, :unauthorized}", %{conn: conn} do
+      meta = checkout_meta()
+      %TestAuthor{id: id} = Factory.insert(:test_author)
+
+      conn = Calcinator.Controller.update(
+        conn,
+        %{
+          "id" => id,
+          "data" => %{
+            "type" => "test-authors",
+            "id" => to_string(id),
+            "attributes" => %{
+              "name" => "Eve"
+            }
+          },
+          "meta" => meta
+        },
+        %Calcinator{
+          authorization_module: Cant,
+          ecto_schema_module: TestAuthor,
+          resources_module: TestAuthors,
+          view_module: TestAuthorView
+        }
+      )
+
+      assert_unauthorized(conn)
+    end
+
+    test "{:error, Alembic.Document.t}", %{conn: conn} do
+      meta = checkout_meta()
+      %TestAuthor{id: id} = Factory.insert(:test_author)
+
+      conn = Calcinator.Controller.update(
+        conn,
+        %{
+          "id" => id,
+          "data" => %{
+            "type" => "test-authors",
+            "id" => to_string(id),
+            "attributes" => %{
+              "name" => "Eve"
+            }
+          },
+          "include" => "post",
+          "meta" => meta
+        },
+        %Calcinator{ecto_schema_module: TestAuthor, resources_module: TestAuthors, view_module: TestAuthorView}
+      )
+
+      assert %{"errors" => errors} = json_response(conn, 422)
+      assert length(errors) == 1
+      assert %{
+               "detail" => "`post` is an unknown relationship path",
+               "meta" => %{
+                 "relationship_path" => "post"
+               },
+               "source" => %{
+                 "parameter" => "include"
+               },
+               "title" => "Unknown relationship path"
+             } in errors
+    end
+
+    test "{:error, Ecto.Changeset.t}", %{conn: conn} do
+      meta = checkout_meta()
+      author = %TestAuthor{id: id} = Factory.insert(:test_author)
+      Factory.insert(:test_post, author: author)
+
+      conn = Calcinator.Controller.update(
+        conn,
+        %{
+          "id" => id,
+          "data" => %{
+            "type" => "test-authors",
+            "id" => to_string(id),
+            "attributes" => %{
+              "name" => nil
+            }
+          },
+          "meta" => meta
+        },
+        %Calcinator{ecto_schema_module: TestAuthor, resources_module: TestAuthors, view_module: TestAuthorView}
+      )
+
+      assert %{"errors" => errors} = json_response(conn, 422)
+      assert length(errors) == 1
+      assert %{
+               "detail" => "Name can't be blank",
+               "source" => %{
+                 "pointer" => "/data/attributes/name"
+               },
+               "title" => "can't be blank"
+             } in errors
+    end
+
+    test "{:error, reason}", %{conn: conn} do
+      meta = checkout_meta()
+      %TestAuthor{id: id} = Factory.insert(:test_author)
+
+      assert_error_reason :update, fn ->
+        Calcinator.Controller.update(
+          conn,
+          %{
+          "id" => id,
+          "data" => %{
+            "type" => "test-authors",
+            "id" => to_string(id),
+            "attributes" => %{
+              "name" => "Eve"
+            }
+          },
+          "meta" => meta
+        },
+          %Calcinator{ecto_schema_module: TestAuthor, resources_module: TestAuthors, view_module: TestAuthorView}
+        )
+      end
+    end
+  end
+
+  # Functions
+
+  ## Private Functions
+
+  defp assert_error_reason(action, plug) do
+    reason = "A secret reason"
+    Application.put_env(:calcinator, TestAuthors, [{action, {:error, reason}}])
+
+    log = capture_log [level: :error], fn ->
+      conn = plug.()
+
+      assert %{"errors" => errors} = json_response(conn, 500)
+      assert [error] = errors
+      assert %{
+               "id" => error_id,
+               "status" => "500",
+               "title" => "Internal Server Error"
+             } = error
+
+      send self(), {:error_id, error_id}
+    end
+
+    error_id = receive do
+      {:error_id, error_id} -> error_id
+    end
+
+    assert String.contains?(log, "id=#{error_id} reason=#{inspect(reason)}")
+  end
+
+  defp assert_not_found(conn, parameter) do
+    assert %{"errors" => errors} = json_response(conn, :not_found)
+    assert is_list(errors)
+    assert length(errors) == 1
+    assert %{
+             "source" => %{
+               "parameter" => parameter
+             },
+             "status" => "404",
+             "title" => "Resource Not Found"
+           } in errors
+  end
+
+  defp assert_sandox_access_disallowed(conn) do
+    assert %{"errors" => errors} = json_response(conn, 422)
+    assert length(errors) == 1
+    assert %{
+             "detail" => "Information in /meta/beam was not enough to grant access to the sandbox",
+             "source" => %{
+               "pointer" => "/meta/beam"
+             },
+             "status" => "422",
+             "title" => "Sandbox Access Disallowed"
+           } in errors
+  end
+
+  defp assert_sandbox_token_missing(conn) do
+    assert %{"errors" => errors} = json_response(conn, 422)
+    assert length(errors) == 1
+    assert %{
+             "detail" => "`/meta/beam` is missing",
+             "meta" => %{
+               "child" => "beam"
+             },
+             "source" => %{
+               "pointer" => "/meta"
+             },
+             "status" => "422",
+             "title" => "Child missing"
+           } in errors
+  end
+
+  defp assert_timeout(conn) do
+    assert %{"errors" => errors} = json_response(conn, 504)
+    assert length(errors) == 1
+    assert %{
+             "status" => "504",
+             "title" => "Gateway Timeout"
+           } in errors
+  end
+
+  defp assert_unauthorized(conn) do
+    assert %{"errors" => errors} = json_response(conn, 403)
+    assert length(errors) == 1
+    assert %{
+             "detail" => "You do not have permission for this resource.",
+             "status" => "403",
+             "title" => "Forbidden"
+           } in errors
+  end
+
+  defp checkout_meta do
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(Repo)
+
+    %{}
+    |> Beam.put(Repo)
+    |> Enum.into(
+         %{},
+         fn {key, value} ->
+           {to_string(key), value}
+         end
+       )
+  end
+
+  defp test_author_resource(test_author = %TestAuthor{id: id}) do
+    %{
+      "type" => "test-authors",
+      "id" => to_string(id),
+      "attributes" => %{
+        "name" => test_author.name
+      },
+      "links" => %{
+        "self" => "/api/v1/test-authors/#{id}"
+      },
+      "relationships" => %{
+        "posts" => %{}
+      }
+    }
+  end
 end

--- a/test/support/calcinator/authorization/cant.ex
+++ b/test/support/calcinator/authorization/cant.ex
@@ -1,0 +1,17 @@
+defmodule Calcinator.Authorization.Cant do
+  @moduledoc """
+  `subject` cant do anything
+  """
+
+  @behaviour Calcinator.Authorization
+
+  # Functions
+
+  ## Calcinator.Authorization callbacks
+
+  def can?(_, _, _), do: false
+  def filter_associations_can(_, _, _) do
+    raise "Should not be invoked"
+  end
+  def filter_can(_, _, _), do: []
+end

--- a/test/support/calcinator/resources/ecto/repo/factory.ex
+++ b/test/support/calcinator/resources/ecto/repo/factory.ex
@@ -18,7 +18,7 @@ defmodule Calcinator.Resources.Ecto.Repo.Factory do
   def test_post_factory do
     %TestPost{
       author: build(:test_author),
-      body: Faker.Lorem.paragraphs()
+      body: Faker.Lorem.sentence()
     }
   end
 end

--- a/test/support/calcinator/resources/ecto/repo/test_authors.ex
+++ b/test/support/calcinator/resources/ecto/repo/test_authors.ex
@@ -14,6 +14,15 @@ defmodule Calcinator.Resources.Ecto.Repo.TestAuthors do
 
   ## Calcinator.Resources.Ecto.Repo callbacks
 
+  def delete(data) do
+    case override(:delete) do
+      nil ->
+        super(data)
+      override ->
+        override
+    end
+  end
+
   def ecto_schema_module, do: TestAuthor
 
   def filter(query, "id", comma_separated_ids) do
@@ -29,5 +38,49 @@ defmodule Calcinator.Resources.Ecto.Repo.TestAuthors do
 
   def filter(_, name, _), do: {:error, unknown_filter(name)}
 
+  def get(id, query_options) do
+    case override(:get) do
+      nil ->
+        super(id, query_options)
+      override ->
+        override
+    end
+  end
+
+  def insert(changeset, query_options) do
+    case override(:insert) do
+      nil ->
+        super(changeset, query_options)
+      override ->
+        override
+    end
+  end
+
+  def list(query_options) do
+    case override(:list) do
+      nil ->
+        super(query_options)
+      override ->
+        override
+    end
+  end
+
   def repo, do: Repo
+
+  def update(changeset, query_options) do
+    case override(:update) do
+      nil ->
+        super(changeset, query_options)
+      override ->
+        override
+    end
+  end
+
+  ## Private Functions
+
+  defp override(action) do
+    :calcinator
+    |> Application.get_env(__MODULE__, [])
+    |> Keyword.get(action)
+  end
 end

--- a/test/support/calcinator/resources/ecto/repo/test_posts.ex
+++ b/test/support/calcinator/resources/ecto/repo/test_posts.ex
@@ -1,0 +1,17 @@
+defmodule Calcinator.Resources.Ecto.Repo.TestPosts do
+  @moduledoc """
+  `Calcinator.Resources.Ecto.Repo.TestPost` resources
+  """
+
+  use Calcinator.Resources.Ecto.Repo
+
+  alias Calcinator.Resources.{Ecto.Repo.Repo, TestPost}
+
+  # Functions
+
+  ## Calcinator.Resources.Ecto.Repo callbacks
+
+  def ecto_schema_module, do: TestPost
+
+  def repo, do: Repo
+end

--- a/test/support/calcinator/resources/test_author.ex
+++ b/test/support/calcinator/resources/test_author.ex
@@ -5,7 +5,7 @@ defmodule Calcinator.Resources.TestAuthor do
 
   use Ecto.Schema
 
-  import Ecto.Changeset, only: [cast: 3, validate_required: 2]
+  import Ecto.Changeset, only: [cast: 3, no_assoc_constraint: 2, validate_required: 2]
 
   schema "authors" do
     field :name, :string
@@ -17,9 +17,19 @@ defmodule Calcinator.Resources.TestAuthor do
 
   # Functions
 
+  def changeset(changeset) do
+    changeset
+    |> no_assoc_constraint(:posts)
+    |> validate_required(required_fields())
+  end
+
   def changeset(model, params) do
     model
-    |> cast(params, ~w(name password password_confirmation)a)
-    |> validate_required(:name)
+    |> cast(params, optional_fields() ++ required_fields())
+    |> changeset()
   end
+
+  def optional_fields, do: ~w(password password_confirmation)a
+
+  def required_fields, do: ~w(name)a
 end

--- a/test/support/calcinator/test_author_view.ex
+++ b/test/support/calcinator/test_author_view.ex
@@ -1,0 +1,36 @@
+defmodule Calcinator.TestAuthorView do
+  @moduledoc """
+  View for `Calcinator.TestAuthor`
+  """
+
+  alias Calcinator.{RelatedView, RelationshipView}
+
+  use JaSerializer.PhoenixView
+  use Calcinator.JaSerializer.PhoenixView,
+      phoenix_view_module: __MODULE__
+
+  location "/api/v1/test-authors/:id"
+
+  # Attributes
+
+  attributes ~w(name)a
+
+  # Relationships
+
+  has_many :posts,
+           serializers: Calcinator.TestPostView
+
+  # Functions
+
+  def render("get_related_resource.json-api", options) do
+    RelatedView.render("get_related_resource.json-api", Map.put(options, :view, __MODULE__))
+  end
+
+  def render("show_relationship.json-api", options) do
+    RelationshipView.render("show_relationship.json-api", Map.put(options, :view, __MODULE__))
+  end
+
+  ## JaSerializer.PhoenixView callbacks
+
+  def type, do: "test-authors"
+end

--- a/test/support/calcinator/test_post_view.ex
+++ b/test/support/calcinator/test_post_view.ex
@@ -1,0 +1,65 @@
+defmodule Calcinator.TestPostView do
+  @moduledoc """
+  View for `Calcinator.TestPost`
+  """
+
+  alias Calcinator.{RelatedView, RelationshipView}
+  alias Calcinator.Resources.TestPost
+
+  use JaSerializer.PhoenixView
+  use Calcinator.JaSerializer.PhoenixView,
+      phoenix_view_module: __MODULE__
+
+  location "/api/v1/test-posts/:id"
+
+  # Attributes
+
+  attributes ~w(body)a
+
+  # Relationships
+
+  has_one :author,
+          serializer: Calcinator.TestAuthorView
+
+  # Functions
+
+  def render("get_related_resource.json-api", options) do
+    RelatedView.render("get_related_resource.json-api", Map.put(options, :view, __MODULE__))
+  end
+
+  def render("show_relationship.json-api", options) do
+    RelationshipView.render("show_relationship.json-api", Map.put(options, :view, __MODULE__))
+  end
+
+  ## JaSerializer.PhoenixView callbacks
+
+  def relationships(test_post, conn) do
+    test_post
+    |> super(conn)
+    |> Enum.filter(relationships_filter(test_post))
+    |> Enum.into(%{})
+  end
+
+  def type, do: "test-posts"
+
+  ## Private Functions
+
+  defp relationships_filter(test_post = %TestPost{}) do
+    not_loaded_names = Enum.reduce(
+      [author: :author],
+      [],
+      fn {field, relationship}, acc ->
+        case Map.get(test_post, field) do
+          %Ecto.Association.NotLoaded{} ->
+            [relationship | acc]
+          _ ->
+            acc
+        end
+      end
+    )
+
+    fn {name, _relationship} ->
+      not name in not_loaded_names
+    end
+  end
+end


### PR DESCRIPTION
# Changelog
## Enhancements
* Pass all JSON errors through `Calcinator.Controller.Error.render_json` to eliminate redundant pipelines.
*  When structs are deleted directly instead of changesets, there's no way to add constraints, such as `no_assoc_constraint` or `assoc_constraint` that would transform DB errors into validation errors, so
   * `Calcinator.delete/3` generate a changeset from `Calcinator.Resources.changeset(struct, %{})`
   * Docs are updated to include tips are using changeset to add constraints
   * The docs for `Calcinator.Resources.changeset/2` is updated so that it states it will be used for both updating (which it was previously) and (now) deleting
* Comment the expected path in the `get_related_resource` and `show_relationship` examples to makes it easier to remember when `get_related_resource` and `show_relationship` are called.
* Test reproducible clauses in `Calcinator.Controller` cases (the majority of the bug fixes came from this testing).  [I couldn't remember how to trigger `{:error, :ownership}` and didn't want to fake it since I know I've produced it before because that's why `wrap_ownership_error` exists.]
* Remove `{:ok, rendered}` duplication in `Calcinator.Controller`
* Deduplicate `related_property` responses in `Calcinator.Controller`
* Extract all the error-tuple handling in `Calcinator.Controller` to `Calcinator.Controller.Error.put_calcinator_error` as most clauses were duplicated in the various actions.  This would technically allow some unexpected errors (like `{:error, {:not_found, parameter}}` for create) to be handled, but it is unlikely to cause problems since it will lead to
`conn` response instead of a `CaseClauseError` as would be the case if some of the clauses were missing as was the case before this PR.
 
## Bug Fixes
* Ensure `Calcinator.Controller` actions have `case` clauses for all the declared return types from `Calcinator` calls.
* Disable `mix docs` backquote check
* `get_related_resources` could not handle has_many related resources, specifically
  * `Calcinator.JaSerializer.PhoenixView.get_related_resource/3` would not allow `data` to be a `list`.
  * `Calcinator.RelatedView.render` with data assumes the data was singular and "links" could be added to that "data" map.
  * `Calcinator.authorized` did not allow the unfiltered data to be `list`.
* Fix `source` `assigns` for `get_related_resource` example: example still used pre-open-sourcing `association` and `id_key`.
* Fix show_relationship example that was just wrong. The same `assigns` as `get_related_resource` should be used.  Since at first I couldn't figure out why showing a relationship would need a view module and I wrote the code, I added a note explaining its for the `view_module.type/0` callback since relationships are resource identifiers with `id` and `type`.
* `Calcinator.RelationshipView.data/1` assumed that `[:related][:resource]` was `nil` or a `map`, which didn't handle the `list` for has_many relationships.

## Incompatible Changes
* `Calcinator.delete` deletes a changeset instead of a resource struct
  * `Calcinator.Resources.delete/1` must expect an `Ecto.Changeset.t`instead of a resource `struct`
  * `use Calcinator.Resources.Ecto.Repo` generates `delete/1` that expects an `Ecto.Changeset.t` and calls `Calcinator.Resources.Ecto.Repo.delete/2`, which now expects a changeset instead of resource struct as the second argument.
