### PR TITLE
many_to_many association support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -203,6 +203,10 @@ jobs:
           at: /home/circleci/calcinator
 
       - run:
+          name: Wait for db
+          command: dockerize -wait tcp://localhost:5432 -timeout 1m
+
+      - run:
           name: "mix test"
           command: mix coveralls.circle
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,50 +3,72 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [Changelog](#changelog)
-  - [v3.0.0](#v300)
+  - [v4.0.0](#v400)
     - [Enhancements](#enhancements)
-    - [Bug Fixes](#bug-fixes)
     - [Incompatible Changes](#incompatible-changes)
-  - [v2.4.0](#v240)
+  - [v3.0.0](#v300)
     - [Enhancements](#enhancements-1)
+    - [Bug Fixes](#bug-fixes)
+    - [Incompatible Changes](#incompatible-changes-1)
+  - [v2.4.0](#v240)
+    - [Enhancements](#enhancements-2)
   - [v2.3.1](#v231)
     - [Bug Fixes](#bug-fixes-1)
   - [v2.3.0](#v230)
-    - [Enhancements](#enhancements-2)
-  - [v2.2.0](#v220)
     - [Enhancements](#enhancements-3)
-  - [v2.1.0](#v210)
+  - [v2.2.0](#v220)
     - [Enhancements](#enhancements-4)
+  - [v2.1.0](#v210)
+    - [Enhancements](#enhancements-5)
     - [Bug Fixes](#bug-fixes-2)
   - [v2.0.0](#v200)
-    - [Enhancements](#enhancements-5)
-    - [Bug Fixes](#bug-fixes-3)
-    - [Incompatible Changes](#incompatible-changes-1)
-  - [v1.7.0](#v170)
     - [Enhancements](#enhancements-6)
+    - [Bug Fixes](#bug-fixes-3)
+    - [Incompatible Changes](#incompatible-changes-2)
+  - [v1.7.0](#v170)
+    - [Enhancements](#enhancements-7)
     - [Bug Fixes](#bug-fixes-4)
   - [v1.6.0](#v160)
-    - [Enhancements](#enhancements-7)
+    - [Enhancements](#enhancements-8)
   - [v1.5.1](#v151)
     - [Bug Fixes](#bug-fixes-5)
   - [v1.5.0](#v150)
-    - [Enhancements](#enhancements-8)
+    - [Enhancements](#enhancements-9)
     - [Bug Fixes](#bug-fixes-6)
   - [v1.4.0](#v140)
-    - [Enhancements](#enhancements-9)
-  - [v1.3.0](#v130)
     - [Enhancements](#enhancements-10)
+  - [v1.3.0](#v130)
+    - [Enhancements](#enhancements-11)
     - [Bug Fixes](#bug-fixes-7)
   - [v1.2.0](#v120)
-    - [Enhancements](#enhancements-11)
+    - [Enhancements](#enhancements-12)
     - [Bug Fixes](#bug-fixes-8)
   - [v1.1.0](#v110)
-    - [Enhancements](#enhancements-12)
+    - [Enhancements](#enhancements-13)
     - [Bug Fixes](#bug-fixes-9)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 # Changelog
+
+## v4.0.0
+
+### Enhancements
+* [#28](https://github.com/C-S-D/calcinator/pull/28) - [@KronicDeth](https://github.com/KronicDeth)
+  * `use Calcinator.Resources.Ecto.Repo`'s `changeset/2` will
+    1. (New) Preload any `many_to_many` associations that appear in `params`
+    2. Cast `params` into `data` using `optional_field/0` and `required_fields/0` of the module
+    3. (New) Puts `many_to_many` associations from `params` into changeset. If any ids don't exist, they will generate changeset errors.
+    4. Validates changeset with `module` `ecto_schema_module/0` `changeset/0`.
+
+### Bug Fixes
+* [#28](https://github.com/C-S-D/calcinator/pull/28) - [@KronicDeth](https://github.com/KronicDeth)
+  * Use `dockerize` to wait for postgres port to open
+  * Use `calcinator.ecto.wait` `mix` task to ensure port can receive queries after opening
+
+### Incompatible Changes
+* [#28](https://github.com/C-S-D/calcinator/pull/28) - [@KronicDeth](https://github.com/KronicDeth)
+  * `Calcinator.Resources.changeset/1,2` return goes from `Ecto.Changeset.t` to `{:ok, Ecto.Changeset.t} | {:error, :ownership}` as `changeset/1,2` will access database to preload, validate ids, and `put_assoc` on `many_to_many` association.  Accessing the database can lead to an ownership error, so `{:error, :ownership}` is necessary.
 
 ## v3.0.0
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,5 +1,11 @@
 # Upgrading
 
+## v4.0.0
+
+### `Calcinator.Resources.changeset/1,2` return types
+
+In order to support preloading of associations as required by `Ecto.Changeset.put_assoc/3` for `many_to_many` association support, `Calcinator.Resources.changeset/1,2` may now access the backing store, which means an `{:error, :ownership}` can occur.  Instead of having the type of the callbacks be `Ecto.Changeset.t | {:error, reason}`, it is better to use a proper Either type and use `{:ok, Ecto.Changeset.t} | {:error, reason}`, so any callback that returned `Ecto.Changeset.t` before must now return `{:ok, Ecto.Changeset.t}`.
+
 ## v3.0.0
 
 ### `Calcinator.Resources.allow_sandbox_access/1` return types

--- a/coveralls.json
+++ b/coveralls.json
@@ -1,5 +1,5 @@
 {
   "coverage_options": {
-    "minimum_coverage": 80.874
+    "minimum_coverage": 77.752
   }
 }

--- a/lib/calcinator.ex
+++ b/lib/calcinator.ex
@@ -100,11 +100,13 @@ defmodule Calcinator do
     end
   end
 
-  @spec changeset(t, Ecto.Schema.t, insertable_params) :: {:ok, Ecto.Changeset.t} | {:error, Ecto.Changeset.t}
+  @spec changeset(t, Ecto.Schema.t, insertable_params) :: {:ok, Ecto.Changeset.t} |
+                                                          {:error, Ecto.Changeset.t} |
+                                                          {:error, :ownership}
   def changeset(%__MODULE__{resources_module: resources_module}, updatable, updatable_params) do
-    updatable
-    |> resources_module.changeset(updatable_params)
-    |> status_changeset()
+    with {:ok, changeset} <- resources_module.changeset(updatable, updatable_params) do
+      status_changeset(changeset)
+    end
   end
 
   @spec get(module, params, id_key :: String.t, Resources.query_options) :: {:ok, Ecto.Schema.t} |
@@ -560,16 +562,16 @@ defmodule Calcinator do
     {deep_filtered, filtered_pagination}
   end
 
-  @spec changeset(t, insertable_params) :: {:ok, Ecto.Changeset.t} | {:error, Ecto.Changeset.t}
+  @spec changeset(t, insertable_params) :: {:ok, Ecto.Changeset.t} | {:error, Ecto.Changeset.t} | {:error, :ownership}
   defp changeset(
          %__MODULE__{resources_module: resources_module},
          insertable_params
        )
        when not is_nil(resources_module) and is_atom(resources_module) and
             is_map(insertable_params) do
-    insertable_params
-    |> resources_module.changeset()
-    |> status_changeset()
+    with {:ok, changeset} <- resources_module.changeset(insertable_params) do
+      status_changeset(changeset)
+    end
   end
 
   @spec create_changeset(t, Ecto.Changeset.t, params) :: {:ok, struct} |

--- a/lib/calcinator/resources.ex
+++ b/lib/calcinator/resources.ex
@@ -56,14 +56,30 @@ defmodule Calcinator.Resources do
 
   @doc """
   Changeset for creating a struct from the `params`
+
+  ## Returns
+
+  * `{:ok, Ecto.Changeset.t}` - a changeset was created with no error while trying to access the backing store
+  * `{:error, :ownership}` - connection to backing store was not owned by the calling process when associations were
+      preloaded into the data for the changeset.  `many_to_many` associations require the associations to be preloaded
+      into the `Ecto.Changeset.t` `data` before calling `Ecto.Changeset.put_assoc/3`.
+
   """
-  @callback changeset(params) :: Ecto.Changeset.t
+  @callback changeset(params) :: {:ok, Ecto.Changeset.t} | {:error, :ownership}
 
   @doc """
   * Changeset for updating `resource` with `params`.
   * Changeset for deleting `resource` (`params` will be an empty map)
+
+  ## Returns
+
+  * `{:ok, Ecto.Changeset.t}` - a changeset was created with no error while trying to access the backing store
+  * `{:error, :ownership}` - connection to backing store was not owned by the calling process when associations were
+      preloaded into the data for the changeset.  `many_to_many` associations require the associations to be preloaded
+      into the `Ecto.Changeset.t` `data` before calling `Ecto.Changeset.put_assoc/3`.
+
   """
-  @callback changeset(resource :: Ecto.Schema.t, params) :: Ecto.Changeset.t
+  @callback changeset(resource :: Ecto.Schema.t, params) :: {:ok, Ecto.Changeset.t} | {:error, :ownership}
 
   @doc """
   Deletes a single struct in a `changeset`

--- a/lib/mix/tasks/calcinator/ecto/wait.ex
+++ b/lib/mix/tasks/calcinator/ecto/wait.ex
@@ -1,0 +1,92 @@
+defmodule Mix.Tasks.Calcinator.Ecto.Wait do
+  @moduledoc """
+  Waits for connection to work to the given repository.
+
+  The repositry must be set under `:ecto_repos` in the
+  current app configuration.
+
+  ## Example
+
+      mix do calcinator.ecto.wait, ecto.create
+
+  """
+
+  use Mix.Task
+
+  require Ecto.Query
+  require Logger
+
+  import Mix.Ecto
+
+  @shortdoc "Waits for database to be ready"
+  @recursive true
+
+  # Constats
+
+  @wait_for_connection_sleep 5_000 # ms
+
+  # Functions
+
+  @doc false
+  def run(args) do
+    repos = parse_repo(args)
+
+    Enum.each repos, fn repo ->
+      ensure_repo(repo, args)
+      ensure_implements(
+        repo.__adapter__,
+        Ecto.Adapter.Storage,
+        "to connect to storage for #{inspect repo}"
+      )
+
+      wait_for_connection(repo.config)
+    end
+  end
+
+  ## Private Functions
+
+  defp connect(opts) do
+    {:ok, _} = Application.ensure_all_started(:postgrex)
+
+    opts =
+      opts
+      |> Keyword.drop([:name, :log])
+      |> Keyword.put(:database, "postgres")
+      |> Keyword.put(:pool, DBConnection.Connection)
+
+    {:ok, conn} = Postgrex.start_link(opts)
+
+    value = try do
+      #repo.all(Ecto.Query.from(a in "pg_stat_activity", select: a.pid))
+      Ecto.Adapters.Postgres.Connection.execute(conn, "SELECT * FROM pg_stat_activity", [], opts)
+    rescue
+      DBConnection.ConnectionError ->
+        :error
+    else
+      _ ->
+        :ok
+    end
+
+    GenServer.stop(conn)
+
+    value
+  end
+
+  defp wait_for_connection(opts) do
+    with :error <- connect(opts) do
+      Logger.warn fn ->
+        [
+          "Could not connect.  Retrying in ",
+          @wait_for_connection_sleep
+          |> div(1000)
+          |> to_string(),
+          " seconds."
+        ]
+      end
+
+      Process.sleep @wait_for_connection_sleep
+
+      wait_for_connection(opts)
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -29,7 +29,7 @@ defmodule Calcinator.Mixfile do
       test_coverage: [
         tool: ExCoveralls
       ],
-      version: "3.0.0"
+      version: "4.0.0"
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -42,7 +42,7 @@ defmodule Calcinator.Mixfile do
 
   defp aliases do
     [
-      "test": ["ecto.drop", "ecto.create --quiet", "ecto.migrate", "test"]
+      "test": ["calcinator.ecto.wait", "ecto.drop", "ecto.create --quiet", "ecto.migrate", "test"]
     ]
   end
 
@@ -57,7 +57,7 @@ defmodule Calcinator.Mixfile do
     [applications: applications(env)]
   end
 
-  defp applications(:test), do: [:ecto, :faker, :postgrex, :ex_machina | applications(:dev)]
+  defp applications(:test), do: [:ecto, :ex_machina, :faker, :mix, :postgrex | applications(:dev)]
   defp applications(_), do: ~w(alembic ja_serializer logger)a
 
   # Dependencies can be Hex packages:

--- a/priv/repo/migrations/20170818223239_add_tags.exs
+++ b/priv/repo/migrations/20170818223239_add_tags.exs
@@ -1,0 +1,9 @@
+defmodule Calcinator.Resources.Ecto.Repo.Repo.Migrations.AddTags do
+  use Ecto.Migration
+
+  def change do
+    create table(:tags) do
+      add :name, :string, null: false
+    end
+  end
+end

--- a/priv/repo/migrations/20170818223420_add_posts_tags.exs
+++ b/priv/repo/migrations/20170818223420_add_posts_tags.exs
@@ -1,0 +1,10 @@
+defmodule Calcinator.Resources.Ecto.Repo.Repo.Migrations.AddPostsTags do
+  use Ecto.Migration
+
+  def change do
+    create table(:posts_tags) do
+      add :post_id, references(:posts), null: false
+      add :tag_id, references(:tags), null: false
+    end
+  end
+end

--- a/test/support/calcinator/resources/ecto/repo/factory.ex
+++ b/test/support/calcinator/resources/ecto/repo/factory.ex
@@ -3,7 +3,7 @@ defmodule Calcinator.Resources.Ecto.Repo.Factory do
   Factories for test schemas.
   """
 
-  alias Calcinator.Resources.{Ecto.Repo.Repo, TestAuthor, TestPost}
+  alias Calcinator.Resources.{Ecto.Repo.Repo, TestAuthor, TestPost, TestTag}
 
   use ExMachina.Ecto, repo: Repo
 
@@ -19,6 +19,12 @@ defmodule Calcinator.Resources.Ecto.Repo.Factory do
     %TestPost{
       author: build(:test_author),
       body: Faker.Lorem.sentence()
+    }
+  end
+
+  def test_tag_factory do
+    %TestTag{
+      name: sequence(:test_post_name, &"tag#{&1}")
     }
   end
 end

--- a/test/support/calcinator/resources/ecto/repo/test_tags.ex
+++ b/test/support/calcinator/resources/ecto/repo/test_tags.ex
@@ -1,0 +1,17 @@
+defmodule Calcinator.Resources.Ecto.Repo.TestTags do
+  @moduledoc """
+  `Calcinator.Resources.Ecto.Repo.TestTag` resources
+  """
+
+  use Calcinator.Resources.Ecto.Repo
+
+  alias Calcinator.Resources.{Ecto.Repo.Repo, TestTag}
+
+  # Functions
+
+  ## Calcinator.Resources.Ecto.Repo callbacks
+
+  def ecto_schema_module, do: TestTag
+
+  def repo, do: Repo
+end

--- a/test/support/calcinator/resources/test_post.ex
+++ b/test/support/calcinator/resources/test_post.ex
@@ -5,12 +5,41 @@ defmodule Calcinator.Resources.TestPost do
 
   use Ecto.Schema
 
+  import Ecto.Changeset, only: [cast: 3, validate_required: 2]
+
+  alias Calcinator.Resources.{TestAuthor, TestComment, TestTag}
+
   schema "posts" do
     field :body, :string
 
     timestamps()
 
-    belongs_to :author, Calcinator.Resources.TestAuthor
-    has_many :comments, Calcinator.Resources.TestComment
+    belongs_to :author, TestAuthor
+    has_many :comments, TestComment
+    many_to_many :tags,
+                 TestTag,
+                 join_keys: [
+                   post_id: :id,
+                   tag_id: :id
+                 ],
+                 join_through: "posts_tags",
+                 on_replace: :delete
   end
+
+  # Functions
+
+  def changeset(changeset) do
+    changeset
+    |> validate_required(required_fields())
+  end
+
+  def changeset(data, params) do
+    data
+    |> cast(params, optional_fields() ++ required_fields())
+    |> changeset()
+  end
+
+  def optional_fields, do: []
+
+  def required_fields, do: ~w(author_id body)a
 end

--- a/test/support/calcinator/resources/test_tag.ex
+++ b/test/support/calcinator/resources/test_tag.ex
@@ -1,0 +1,24 @@
+defmodule Calcinator.Resources.TestTag do
+  @moduledoc """
+  A schema used in examples in `Calcinator.Resources`
+  """
+
+  use Ecto.Schema
+
+  alias Calcinator.Resources.TestPost
+
+  schema "tags" do
+    field :name, :string
+
+    # Associations
+
+    many_to_many :posts,
+                 TestPost,
+                 join_keys: [
+                   tag_id: :id,
+                   post_id: :id
+                 ],
+                 join_through: "posts_tags",
+                 on_replace: :delete
+  end
+end

--- a/test/support/calcinator/test_post_view.ex
+++ b/test/support/calcinator/test_post_view.ex
@@ -3,7 +3,7 @@ defmodule Calcinator.TestPostView do
   View for `Calcinator.TestPost`
   """
 
-  alias Calcinator.{RelatedView, RelationshipView}
+  alias Calcinator.{RelatedView, RelationshipView, TestAuthorView, TestTagView}
   alias Calcinator.Resources.TestPost
 
   use JaSerializer.PhoenixView
@@ -19,7 +19,9 @@ defmodule Calcinator.TestPostView do
   # Relationships
 
   has_one :author,
-          serializer: Calcinator.TestAuthorView
+          serializer: TestAuthorView
+  has_many :tags,
+           serializer: TestTagView
 
   # Functions
 

--- a/test/support/calcinator/test_tag_view.ex
+++ b/test/support/calcinator/test_tag_view.ex
@@ -1,0 +1,36 @@
+defmodule Calcinator.TestTagView do
+  @moduledoc """
+  View for `Calcinator.TestTag`
+  """
+
+  alias Calcinator.{RelatedView, RelationshipView, TestPostView}
+
+  use JaSerializer.PhoenixView
+  use Calcinator.JaSerializer.PhoenixView,
+      phoenix_view_module: __MODULE__
+
+  location "/api/v1/test-tags/:id"
+
+  # Attributes
+
+  attributes ~w(name)a
+
+  # Relationships
+
+  has_many :posts,
+           serializers: TestPostView
+
+  # Functions
+
+  def render("get_related_resource.json-api", options) do
+    RelatedView.render("get_related_resource.json-api", Map.put(options, :view, __MODULE__))
+  end
+
+  def render("show_relationship.json-api", options) do
+    RelationshipView.render("show_relationship.json-api", Map.put(options, :view, __MODULE__))
+  end
+
+  ## JaSerializer.PhoenixView callbacks
+
+  def type, do: "test-tags"
+end


### PR DESCRIPTION
## Enhancements
* `use Calcinator.Resources.Ecto.Repo`'s `changeset/2` will
  1. (New) Preload any `many_to_many` associations that appear in `params`
  2. Cast `params` into `data` using `optional_field/0` and `required_fields/0` of the module
  3. (New) Puts `many_to_many` associations from `params` into changeset. If any ids don't exist, they will generate changeset errors.
  4. Validates changeset with `module` `ecto_schema_module/0` `changeset/0`.

## Bug Fixes
* Use `dockerize` to wait for postgres port to open
* Use `calcinator.ecto.wait` `mix` task to ensure port can receive queries after opening


## Incompatible Changes
* `Calcinator.Resources.changeset/1,2` return goes from `Ecto.Changeset.t` to `{:ok, Ecto.Changeset.t} | {:error, :ownership}` as `changeset/1,2` will access database to preload, validate ids, and `put_assoc` on `many_to_many` association.  Accessing the database can lead to an ownership error, so `{:error, :ownership}` is necessary.