### PR TITLE
allow_sandbox_access before getting changeset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,53 +3,62 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [Changelog](#changelog)
+  - [v4.0.1](#v401)
+    - [Bug Fixes](#bug-fixes)
   - [v4.0.0](#v400)
     - [Enhancements](#enhancements)
+    - [Bug Fixes](#bug-fixes-1)
     - [Incompatible Changes](#incompatible-changes)
   - [v3.0.0](#v300)
     - [Enhancements](#enhancements-1)
-    - [Bug Fixes](#bug-fixes)
+    - [Bug Fixes](#bug-fixes-2)
     - [Incompatible Changes](#incompatible-changes-1)
   - [v2.4.0](#v240)
     - [Enhancements](#enhancements-2)
   - [v2.3.1](#v231)
-    - [Bug Fixes](#bug-fixes-1)
+    - [Bug Fixes](#bug-fixes-3)
   - [v2.3.0](#v230)
     - [Enhancements](#enhancements-3)
   - [v2.2.0](#v220)
     - [Enhancements](#enhancements-4)
   - [v2.1.0](#v210)
     - [Enhancements](#enhancements-5)
-    - [Bug Fixes](#bug-fixes-2)
+    - [Bug Fixes](#bug-fixes-4)
   - [v2.0.0](#v200)
     - [Enhancements](#enhancements-6)
-    - [Bug Fixes](#bug-fixes-3)
+    - [Bug Fixes](#bug-fixes-5)
     - [Incompatible Changes](#incompatible-changes-2)
   - [v1.7.0](#v170)
     - [Enhancements](#enhancements-7)
-    - [Bug Fixes](#bug-fixes-4)
+    - [Bug Fixes](#bug-fixes-6)
   - [v1.6.0](#v160)
     - [Enhancements](#enhancements-8)
   - [v1.5.1](#v151)
-    - [Bug Fixes](#bug-fixes-5)
+    - [Bug Fixes](#bug-fixes-7)
   - [v1.5.0](#v150)
     - [Enhancements](#enhancements-9)
-    - [Bug Fixes](#bug-fixes-6)
+    - [Bug Fixes](#bug-fixes-8)
   - [v1.4.0](#v140)
     - [Enhancements](#enhancements-10)
   - [v1.3.0](#v130)
     - [Enhancements](#enhancements-11)
-    - [Bug Fixes](#bug-fixes-7)
+    - [Bug Fixes](#bug-fixes-9)
   - [v1.2.0](#v120)
     - [Enhancements](#enhancements-12)
-    - [Bug Fixes](#bug-fixes-8)
+    - [Bug Fixes](#bug-fixes-10)
   - [v1.1.0](#v110)
     - [Enhancements](#enhancements-13)
-    - [Bug Fixes](#bug-fixes-9)
+    - [Bug Fixes](#bug-fixes-11)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 # Changelog
+
+## v4.0.1
+
+### Bug Fixes
+* [#30](https://github.com/C-S-D/calcinator/pull/30) - [@KronicDeth](https://github.com/KronicDeth)
+  * `Calcinator.Resources.changeset/1,2` is allowed to get `many_to_many` associations from the backing store, so during testing, this means that the sandbox access must be allowed prior to calling `changeset`.  This was already the case for other actions, but for `create`, `allow_sandbox_access` was not called until the `Ecto.Changeset.t` was authorized and about to be created.
 
 ## v4.0.0
 

--- a/lib/calcinator.ex
+++ b/lib/calcinator.ex
@@ -189,6 +189,7 @@ defmodule Calcinator do
     with :ok <- can(state, :create, ecto_schema_module),
          {:ok, document} <- document(params, :create),
          insertable_params = insertable_params(state, document),
+         :ok <- allow_sandbox_access(state, params),
          {:ok, changeset} <- changeset(state, insertable_params),
          :ok <- can(state, :create, changeset),
          {:ok, created} <- create_changeset(state, changeset, params) do
@@ -583,8 +584,7 @@ defmodule Calcinator do
                                                          {:error, Ecto.Changeset.t}
   defp create_changeset(state = %__MODULE__{resources_module: resources_module}, changeset = %Ecto.Changeset{}, params)
        when not is_nil(resources_module) and is_atom(resources_module) do
-    with {:ok, query_options} <- params_to_query_options(state, params),
-         :ok <- allow_sandbox_access(state, params) do
+    with {:ok, query_options} <- params_to_query_options(state, params) do
       resources_module.insert(changeset, query_options)
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -29,7 +29,7 @@ defmodule Calcinator.Mixfile do
       test_coverage: [
         tool: ExCoveralls
       ],
-      version: "4.0.0"
+      version: "4.0.1"
     ]
   end
 


### PR DESCRIPTION
# Changelog
## Bug Fixes
* `Calcinator.Resources.changeset/1,2` is allowed to get `many_to_many` associations from the backing store, so during testing, this means that the sandbox access must be allowed prior to calling `changeset`.  This was already the case for other actions, but for `create`, `allow_sandbox_access` was not called until the `Ecto.Changeset.t` was authorized and about to be created.