### PR TITLE
VPP-2947: Optional PryIn Instrumentation support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,6 +148,7 @@ jobs:
             - dialyze-{{ checksum "OTP_VERSION.lock" }}-{{ checksum "ELIXIR_VERSION.lock" }}-{{ checksum "mix.exs" }}
             - dialyze-{{ checksum "OTP_VERSION.lock" }}-{{ checksum "ELIXIR_VERSION.lock" }}
 
+      - run: mix compile --no-warnings-as-errors
       - run: mix dialyze --no-analyse
 
       - save_cache: &dialyze_save_cache_mix_lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,56 +3,94 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [Changelog](#changelog)
-  - [v4.0.1](#v401)
-    - [Bug Fixes](#bug-fixes)
-  - [v4.0.0](#v400)
+  - [v5.0.0](#v500)
     - [Enhancements](#enhancements)
-    - [Bug Fixes](#bug-fixes-1)
+    - [Bug Fixes](#bug-fixes)
     - [Incompatible Changes](#incompatible-changes)
-  - [v3.0.0](#v300)
+  - [v4.0.1](#v401)
+    - [Bug Fixes](#bug-fixes-1)
+  - [v4.0.0](#v400)
     - [Enhancements](#enhancements-1)
     - [Bug Fixes](#bug-fixes-2)
     - [Incompatible Changes](#incompatible-changes-1)
-  - [v2.4.0](#v240)
+  - [v3.0.0](#v300)
     - [Enhancements](#enhancements-2)
-  - [v2.3.1](#v231)
     - [Bug Fixes](#bug-fixes-3)
-  - [v2.3.0](#v230)
+    - [Incompatible Changes](#incompatible-changes-2)
+  - [v2.4.0](#v240)
     - [Enhancements](#enhancements-3)
-  - [v2.2.0](#v220)
-    - [Enhancements](#enhancements-4)
-  - [v2.1.0](#v210)
-    - [Enhancements](#enhancements-5)
+  - [v2.3.1](#v231)
     - [Bug Fixes](#bug-fixes-4)
-  - [v2.0.0](#v200)
+  - [v2.3.0](#v230)
+    - [Enhancements](#enhancements-4)
+  - [v2.2.0](#v220)
+    - [Enhancements](#enhancements-5)
+  - [v2.1.0](#v210)
     - [Enhancements](#enhancements-6)
     - [Bug Fixes](#bug-fixes-5)
-    - [Incompatible Changes](#incompatible-changes-2)
-  - [v1.7.0](#v170)
+  - [v2.0.0](#v200)
     - [Enhancements](#enhancements-7)
     - [Bug Fixes](#bug-fixes-6)
-  - [v1.6.0](#v160)
+    - [Incompatible Changes](#incompatible-changes-3)
+  - [v1.7.0](#v170)
     - [Enhancements](#enhancements-8)
-  - [v1.5.1](#v151)
     - [Bug Fixes](#bug-fixes-7)
-  - [v1.5.0](#v150)
+  - [v1.6.0](#v160)
     - [Enhancements](#enhancements-9)
+  - [v1.5.1](#v151)
     - [Bug Fixes](#bug-fixes-8)
-  - [v1.4.0](#v140)
+  - [v1.5.0](#v150)
     - [Enhancements](#enhancements-10)
-  - [v1.3.0](#v130)
-    - [Enhancements](#enhancements-11)
     - [Bug Fixes](#bug-fixes-9)
-  - [v1.2.0](#v120)
+  - [v1.4.0](#v140)
+    - [Enhancements](#enhancements-11)
+  - [v1.3.0](#v130)
     - [Enhancements](#enhancements-12)
     - [Bug Fixes](#bug-fixes-10)
-  - [v1.1.0](#v110)
+  - [v1.2.0](#v120)
     - [Enhancements](#enhancements-13)
     - [Bug Fixes](#bug-fixes-11)
+  - [v1.1.0](#v110)
+    - [Enhancements](#enhancements-14)
+    - [Bug Fixes](#bug-fixes-12)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 # Changelog
+
+## v5.0.0
+
+### Enhancements
+* [#31](https://github.com/C-S-D/calcinator/pull/31) - [@KronicDeth](https://github.com/KronicDeth)
+  * `Calcinator` now instruments calls to subsystem with events, similar to `Phoenix` instrumentation.
+
+    | event                      | subsystem                  |
+    |----------------------------|----------------------------|
+    | `alembic`                  | `Alembic`                  |
+    | `calcinator_authorization` | `Calcinator.Authorization` |
+    | `calcinator_resources`     | `Calcinator.Resources`     |
+    | `calcinator_view`          | `Calcinator.View`          |
+
+    Instrumenters can be configured with
+
+    ```elixir
+    config :calcinator,
+               instrumenters: [...]
+    ```
+
+    * [`pryin`](https://github.com/pryin-io/pryin) instrumentation can be configured following the [`pryin` installation instructions](https://github.com/pryin-io/pryin#installation) and then adding `Calcinator.PryIn.Instrumenter` to your `:calcinator` config
+
+       ```elixir
+       config :calcinator,
+               :instrumenters: [Calcinator.PryIn.Instrumenter]
+
+    * Custom instrumenters can be created following the docs in `Calcinator.Instrument`
+
+### Bug Fixes
+* [#31](https://github.com/C-S-D/calcinator/pull/31) - The `@typedoc` and `@type` for `Calcinator.t` now has all the current struct fields documented and typed. - [@KronicDeth](https://github.com/KronicDeth)
+
+### Incompatible Changes
+* [#31](https://github.com/C-S-D/calcinator/pull/31) - In order to facilitate passing the entire `Calcinator.t` struct to `calcinator_resources` event callbacks in instrumenters, `Calcinator. get(Calcinator.Resources.t, params, id_key :: String.t, Resources.query_options)` has changed to `Calcinator. get(Calcinator.t, params, id_key :: String.t, Resources.query_options)`: The first argument must be the entire `Calcinator.t` struct instead of the `Calcinator.Resources.t` module that was in the `Calcinator.t` `resources_module` field. - [@KronicDeth](https://github.com/KronicDeth)
 
 ## v4.0.1
 

--- a/README.md
+++ b/README.md
@@ -532,3 +532,34 @@ defmodule LocalAppWeb.PostController do
 end
 ```
 --- `apps/local_app_web/lib/local_app_web/post_controller.ex`
+
+## Instrumentation
+
+`Calcinator` supports instrumentation similar to `Phoenix`: calls in `Calcinator` will fire instrumentation events around calls to subsystems.
+
+| event                      | subsystem                  |
+|----------------------------|----------------------------|
+| `alembic`                  | `Alembic`                  |
+| `calcinator_authorization` | `Calcinator.Authorization` |
+| `calcinator_resources`     | `Calcinator.Resources`     |
+| `calcinator_view`          | `Calcinator.View`          |
+
+### PryIn.IO
+
+`Calcinator` ships with support for [pryin.io](https://pryin.io).
+
+You can turn on PryIn support following the [`pryin` installation instructions](https://github.com/pryin-io/pryin#installation) and then adding `Calcinator.PryIn.Instrumenter` to your `:calcinator` config
+
+```
+config :calcinator,
+       instrumenters: [Calcinator.PryIn.Instrumenter]
+```
+
+### Custom
+
+You can write your own Instrumenter following the instructions in the `Calcinator.Instrument` documentation and then configuring `:calcinator` to use your custom instrumenter.
+
+```
+config :calcinator,
+       instrumenters: [MyLib.Calcinator.Instrumenter]
+```

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,5 +1,23 @@
 # Upgrading
 
+## v5.0.0
+
+### `Calcinator.get/4` first argument
+
+In order to support passing the entire `Calcinator.t` struct to `calcinator_resources` event callbacks in instrumenters (`Callback.Instrumenter`), `Calcinator.get/4` now requires a `Calcinator.t` for the first argument instead of the `Calcinator.Resources.t` module.
+
+Before
+
+```elixir
+Calcinator.get(calcinator.resources_module, params, "id", query_options)
+```
+
+After
+
+```elixir
+Calcinator.get(calcinator, params, "id", query_options)
+```
+
 ## v4.0.0
 
 ### `Calcinator.Resources.changeset/1,2` return types

--- a/config/test.exs
+++ b/config/test.exs
@@ -5,12 +5,14 @@ config :calcinator,
        adapter: Ecto.Adapters.Postgres,
        database: "calcinator_test",
        hostname: "localhost",
+       loggers: [PryIn.EctoLogger, Ecto.LogEntry],
        password: "postgres",
        pool: Ecto.Adapters.SQL.Sandbox,
        username: "postgres"
 
 config :calcinator,
-       ecto_repos: [Calcinator.Resources.Ecto.Repo.Repo]
+       ecto_repos: [Calcinator.Resources.Ecto.Repo.Repo],
+       instrumenters: [Calcinator.PryIn.Instrumenter]
 
 # Print only warnings and errors during test
 config :logger,
@@ -18,3 +20,8 @@ config :logger,
 
 config :phoenix, :format_encoders,
        "json-api": Poison
+
+config :pryin,
+       api: Calcinator.PryIn.Api.Test,
+       env: :staging,
+       otp_app: :calcinator

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,6 +1,11 @@
 use Mix.Config
 
 config :calcinator,
+       Calcinator.Endpoint,
+       instrumenters: [PryIn.Instrumenter],
+       secret_key_base: "WUUiQKAzwOqYmugHEp5mBtPC4AJ8I16tZTIbxT5ZvOpZNrIIUFek1lrHWOTMAHHk"
+
+config :calcinator,
        Calcinator.Resources.Ecto.Repo.Repo,
        adapter: Ecto.Adapters.Postgres,
        database: "calcinator_test",
@@ -17,6 +22,11 @@ config :calcinator,
 # Print only warnings and errors during test
 config :logger,
        level: :warn
+
+# Add JSON:API to known mimes
+config :mime, :types, %{
+  "application/vnd.api+json" => ["json-api"]
+}
 
 config :phoenix, :format_encoders,
        "json-api": Poison

--- a/coveralls.json
+++ b/coveralls.json
@@ -1,5 +1,5 @@
 {
   "coverage_options": {
-    "minimum_coverage": 77.752
+    "minimum_coverage": 80.721
   }
 }

--- a/lib/calcinator.ex
+++ b/lib/calcinator.ex
@@ -589,18 +589,20 @@ defmodule Calcinator do
 
   @spec document(params, FromJson.action) :: {:ok, Document.t} | {:error, Document.t}
   defp document(raw_params, action) do
-    Document.from_json(
-      raw_params,
-      %Alembic.Error{
-        meta: %{
-          "action" => action,
-          "sender" => :client
-        },
-        source: %Source{
-          pointer: ""
+    instrument :alembic, %{action: action, params: raw_params}, fn ->
+      Document.from_json(
+        raw_params,
+        %Alembic.Error{
+          meta: %{
+            "action" => action,
+            "sender" => :client
+          },
+          source: %Source{
+            pointer: ""
+          }
         }
-      }
-    )
+      )
+    end
   end
 
   @spec get(t, params) :: {:ok, Ecto.Schema.t} |

--- a/lib/calcinator/instrument.ex
+++ b/lib/calcinator/instrument.ex
@@ -105,6 +105,21 @@ defmodule Calcinator.Instrument do
 
       authorization_module.can?(subject, :create, %Ecto.Changeset{data: %ecto_schema_module{}})
 
+  #### `:delete`
+
+  There is only one call to authorize `:delete`.
+
+      calcinator_can(:start,
+                     compile_metadata :: %{module: module, function: String.t, file: String.t, line: non_neg_integer},
+                     runtime_metdata :: %{action: :create
+                                          calcinator: %Calcinator{
+                                            authorizaton_module: module
+                                            ecto_schema_module: ecto_schema_module
+                                          },
+                                          target: %ecto_schema_module{}})
+
+      authorization_module.can?(subject, :delete, %ecto_schema_module{})
+
   """
 
   require Logger

--- a/lib/calcinator/instrument.ex
+++ b/lib/calcinator/instrument.ex
@@ -89,6 +89,8 @@ defmodule Calcinator.Instrument do
                                           },
                                           target: ecto_schema_module})
 
+  Before
+
       authorization_module.can?(subject, :create, ecto_schema_module)
 
   If the `subject` can create `ecto_schema_module` structs in general, then a second call will check if the specific
@@ -102,6 +104,8 @@ defmodule Calcinator.Instrument do
                                              ecto_schema_module: ecto_schema_module
                                            },
                                            target: %Ecto.Changeset{data: %ecto_schema_module{}}})
+
+  Before
 
       authorization_module.can?(subject, :create, %Ecto.Changeset{data: %ecto_schema_module{}})
 
@@ -133,6 +137,8 @@ defmodule Calcinator.Instrument do
                                           },
                                           target: ecto_schema_module})
 
+  Before
+
       authorization_module.can?(subject, :index, ecto_schema_module)
 
   #### `:show`
@@ -140,7 +146,10 @@ defmodule Calcinator.Instrument do
   ##### `Calcinator.get_related_resource/3`
 
   There is not a special `action` for authorizing `Calcinator.get_related_resource/3`, instead the `source` is authorized
-  for `:show`.  **NOTE: This is the same pattern as for `Calcinator.show/2` and `Calcinator.show_relationship/3`.**
+  for `:show`.
+
+  *NOTE: This is the same pattern as for `Calcinator.show/2`, `Calcinator.show_relationship/3`, and
+  `Calcinator.update/2`.*
 
       calcinator_can(:start,
                      compile_metadata :: %{module: module, function: String.t, file: String.t, line: non_neg_integer},
@@ -150,27 +159,34 @@ defmodule Calcinator.Instrument do
                                             ecto_schema_module: ecto_schema_module
                                           },
                                           target: %ecto_schema_module{}})
+
+  Before
 
       authorization_module.can?(subject, :show, %ecto_schema_module{})
 
   If the `source` can be shown, then its checked if the `related` can be show in an association ascent under `source`.
-  **NOTE: This is the same pattern as for `Calcinator.show_relationship/3`.**
 
-     calcinator_can(:start,
-                    compile_metadata :: %{module: module, function: String.t, file: String.t, line: non_neg_integer},
-                    runtime_metdata :: %{action: :show
-                                         calcinator: %Calcinator{
-                                           authorizaton_module: module
-                                           ecto_schema_module: ecto_schema_module
-                                         },
-                                         target: [%related_ecto_schema_module{}, %ecto_schema_module{}])
+  *NOTE: This is the same pattern as for `Calcinator.show_relationship/3`.*
 
-     authorization_module.can?(subject, :show, [%related_ecto_schema_module{}, %ecto_schema_module{}])
+      calcinator_can(:start,
+                     compile_metadata :: %{module: module, function: String.t, file: String.t, line: non_neg_integer},
+                     runtime_metdata :: %{action: :show
+                                          calcinator: %Calcinator{
+                                            authorizaton_module: module
+                                            ecto_schema_module: ecto_schema_module
+                                          },
+                                          target: [%related_ecto_schema_module{}, %ecto_schema_module{}])
+
+  Before
+
+      authorization_module.can?(subject, :show, [%related_ecto_schema_module{}, %ecto_schema_module{}])
 
   ##### `Calcinator.show/2`
 
-  The primary data is authorized for `:show`. **NOTE: This is the same pattern as the authorization to `:show` the
-  `source` for `Calcinator.get_related_resource/3` and `Calcinator.show_relationship/3`.
+  The primary data is authorized for `:show`.
+
+  *NOTE: This is the same pattern as the authorization to `:show` the `source` for `Calcinator.get_related_resource/3`,
+  `Calcinator.show_relationship/3`, and `Calcinator.update/2`.*
 
       calcinator_can(:start,
                      compile_metadata :: %{module: module, function: String.t, file: String.t, line: non_neg_integer},
@@ -180,13 +196,18 @@ defmodule Calcinator.Instrument do
                                             ecto_schema_module: ecto_schema_module
                                           },
                                           target: %ecto_schema_module{}})
+
+  Before
 
       authorization_module.can?(subject, :show, %ecto_schema_module{})
 
   ##### `Calcinator.show_relationship/3`
 
   There is not a special `action` for authorizing `Calcinator.show_relationship/3`, instead the `source` is authorized
-  for `:show`.  **NOTE: This is the same pattern as for `Calcinator.show/2` and `Calcinator.get_related_resource/3`.**
+  for `:show`.
+
+  *NOTE: This is the same pattern as for `Calcinator.show/2`, `Calcinator.get_related_resource/3`, and
+  `Calcinator.update/2`.*
 
       calcinator_can(:start,
                      compile_metadata :: %{module: module, function: String.t, file: String.t, line: non_neg_integer},
@@ -197,21 +218,63 @@ defmodule Calcinator.Instrument do
                                           },
                                           target: %ecto_schema_module{}})
 
+  Before
+
       authorization_module.can?(subject, :show, %ecto_schema_module{})
 
   If the `source` can be shown, then its checked if the `related` can be show in an association ascent under `source`.
-  **NOTE: This is the same pattern as for `Calcinator.get_related_resource/3`.**
 
-     calcinator_can(:start,
-                    compile_metadata :: %{module: module, function: String.t, file: String.t, line: non_neg_integer},
-                    runtime_metdata :: %{action: :show
-                                         calcinator: %Calcinator{
-                                           authorizaton_module: module
-                                           ecto_schema_module: ecto_schema_module
-                                         },
-                                         target: [%related_ecto_schema_module{}, %ecto_schema_module{}])
+  *NOTE: This is the same pattern as for `Calcinator.get_related_resource/3`.*
 
-     authorization_module.can?(subject, :show, [%related_ecto_schema_module{}, %ecto_schema_module{}])
+      calcinator_can(:start,
+                     compile_metadata :: %{module: module, function: String.t, file: String.t, line: non_neg_integer},
+                     runtime_metdata :: %{action: :show
+                                          calcinator: %Calcinator{
+                                            authorizaton_module: module
+                                            ecto_schema_module: ecto_schema_module
+                                          },
+                                          target: [%related_ecto_schema_module{}, %ecto_schema_module{}])
+
+  Before
+
+      authorization_module.can?(subject, :show, [%related_ecto_schema_module{}, %ecto_schema_module{}])
+
+  ##### `Calcinator.update/3`
+
+  Before a `target` can be updated, it is checked that `subject` can `:show` the target. **NOTE: This is the same
+  pattern as for `Calcinator.show/2`, `Calcinator.get_related_resource/3`, and `Calcinator.show_relatonship/3`.**
+
+      calcinator_can(:start,
+                     compile_metadata :: %{module: module, function: String.t, file: String.t, line: non_neg_integer},
+                     runtime_metdata :: %{action: :show
+                                          calcinator: %Calcinator{
+                                            authorizaton_module: module
+                                            ecto_schema_module: ecto_schema_module
+                                          },
+                                          target: %ecto_schema_module{}})
+
+  Before
+
+      authorization_module.can?(subject, :show, %ecto_schema_module{})
+
+  #### `:update`
+
+  ##### `Calcinator.update/3`
+
+  If a `target` is authorized for `:show`, it is checked if the `subject` can update the `Ecto.Changeset.t`.
+
+      calcinator_can(:start,
+                     compile_metadata :: %{module: module, function: String.t, file: String.t, line: non_neg_integer},
+                     runtime_metdata :: %{action: :update
+                                          calcinator: %Calcinator{
+                                            authorizaton_module: module
+                                            ecto_schema_module: ecto_schema_module
+                                          },
+                                          target: %Ecto.Changeset{data: %ecto_schema_module{}}})
+
+  Before
+
+      authorization_module.can?(subject, :update, %Ecto.Changeset{data: %ecto_schema_module{}})
 
   """
 

--- a/lib/calcinator/instrument.ex
+++ b/lib/calcinator/instrument.ex
@@ -1,0 +1,216 @@
+# Based on https://raw.githubusercontent.com/phoenixframework/phoenix/d6106c692311a2dfbba95243af144481124aad46/lib/
+#   phoenix/endpoint/instrument.ex
+# Switch to the generic Application Performance Monitor library once Chris McCord releases it.
+defmodule Calcinator.Instrument do
+  @moduledoc """
+  Similar to Phoenix, Calcinator supports instrumenters that can receive events from `Calcinator`.
+
+  The `instrument/3` macro is responsible for measuring the time it takes for the event to be processed and for
+  notifying a list of interested instrumenter modules of this measurement.
+
+  You can configure this list of instrumenter modules in the compile-time
+  configuration for Calcinator.
+
+      config :calcinator,
+             instrumenters: [MyApp.Instrumenter]
+
+  The way these modules express their interest in events is by exporting public functions where the name of each
+  function is the name of an event.  The list of defined events is in "Events" section below.
+
+  ### Callbacks cycle
+
+  The event callback sequence is:
+
+    1. The event callback is called *before* the event happens with the atom `:start` as the first argument; see the
+       "`:start` clause" section below.
+    2. The event occurs
+    3. The same event callback is called again, this time with the atom `:stop` as the first argument; see the
+       "`:stop` clause" section below.
+
+  The second and third argument that each event callback takes depends on the value of the first argument, `:start` or
+  `:stop`. For this reason, most of the time you will want to define (at least) two separate clauses for each event
+  callback, one for the `:start` and one for the `:stop` callbacks.
+
+  All event callbacks are run in the same process that calls the `instrument/3` macro; hence, instrumenters should be
+  careful to avoid performing blocking actions. If an event callback fails in any way (exits, throws, or raises), it
+  won't affect anything as the error is caught, but the failure will be logged. Note that `:stop` callbacks are not
+  guaranteed to be called as, for example, a link may break before they've been called.
+
+  #### `:start` clause
+
+  When the first argument to an event callback is `:start`, the signature of that callback is:
+
+      event_callback(:start,
+                     compile_metadata :: %{module: module, function: String.t, file: String.t, line: non_neg_integer},
+                     runtime_metadata :: map) :: any
+
+  where:
+
+    * `compile_metadata` is a map of compile-time metadata about the environment
+      where `instrument/3` has been called.
+      * `:function` - "\#{name}/\#{arity}" of function where `instrument/3` has been called.
+    * `runtime_metadata` is a map of runtime data that the instrumentation passes to the callbacks. It varies per call.
+      See "Events" below for a list of defined events.
+
+  #### `:stop` clause
+
+  When the first argument to an event callback is `:stop`, the signature of that callback is:
+
+      event_callback(:stop, time_diff :: non_neg_integer, result_of_start_callback :: any)
+
+  where:
+
+    * `time_diff` is an integer representing the time it took to execute the instrumented function **in native units**.
+    * `result_of_start_callback` is the return value of the `:start` clause of the same `event_callback`. This is a
+       means of passing data from the `:start` clause to the `:stop` clause when instrumenting.
+
+  The return value of each `:start` event callback will be stored and passed to the corresponding `:stop` callback.
+
+  ### Events
+
+  ### `:calcinator_can`
+
+  `:calcinator_can` occurs around calls to the `authorization_module.can?/3` in `Calcinator.can?/3` to measure how long
+  it takes to authorize actions on the primary target.
+
+  #### `:create`
+
+  There are two calls to authorize `:create`.
+
+  The first call will use the `ecto_schema_module` as the `target` to check if `ecto_schema_module` structs can be
+  created in general by the `subject`.
+
+      calcinator_can(:start,
+                     compile_metadata :: %{module: module, function: String.t, file: String.t, line: non_neg_integer},
+                     runtime_metdata :: %{action: :create
+                                          calcinator: %Calcinator{
+                                            authorizaton_module: module
+                                            ecto_schema_module: ecto_schema_module
+                                          },
+                                          target: ecto_schema_module})
+
+      authorization_module.can?(subject, :create, ecto_schema_module)
+
+  If the `subject` can create `ecto_schema_module` structs in general, then a second call will check if the specific
+  `Ecto.Changeset.t` can be created.
+
+      calcinator_can(:start,
+                     compile_metadata :: %{module: module, function: String.t, file: String.t, line: non_neg_integer},
+                     runtime_metadata :: %{action: :create,
+                                           calcinator: %Calcinator{
+                                             authorizaton_module: module
+                                             ecto_schema_module: ecto_schema_module
+                                           },
+                                           target: %Ecto.Changeset{data: %ecto_schema_module{}}})
+
+      authorization_module.can?(subject, :create, %Ecto.Changeset{data: %ecto_schema_module{}})
+
+  """
+
+  require Logger
+
+  import Calcinator.Instrumenters
+
+  # Macros
+
+  @doc """
+  Instruments the given function.
+
+  `event` is the event identifier (usually an atom) that specifies which
+  instrumenting function to call in the instrumenter modules. `runtime` is
+  metadata to be associated with the event at runtime (e.g., the query being
+  issued if the event to instrument is a DB query).
+
+  ## Predefined Events
+
+  ### Examples
+
+      instrument :calcinator_can, %{action: action, calcinator: calcinator, target: target}, fn ->
+        ...
+      end
+
+  """
+  defmacro instrument(event, runtime \\ Macro.escape(%{}), fun) do
+    compile = __CALLER__
+              |> strip_caller()
+              |> Macro.escape()
+
+    quote do
+      import Calcinator.Instrument, only: [instrument: 4]
+
+      instrument(
+        unquote(event),
+        unquote(compile),
+        unquote(runtime),
+        unquote(fun)
+      )
+    end
+  end
+
+  # Functions
+
+  # For each event in any of the instrumenters, we must generate a
+  # clause of the `instrument/4` function. It'll look like this:
+  #
+  #   def instrument(:my_event, compile, runtime, fun) do
+  #     res0 = Inst0.my_event(:start, compile, runtime)
+  #     ...
+  #
+  #     start = :erlang.monotonic_time
+  #     try do
+  #       fun.()
+  #     after
+  #       diff = ...
+  #       Inst0.my_event(:stop, diff, res0)
+  #       ...
+  #     end
+  #   end
+  #
+  @doc false
+  def instrument(event, compile, runtime, fun)
+
+  for {event, instrumenters} <- app_instrumenters() do
+    def instrument(unquote(event), var!(compile), var!(runtime), fun)
+        when is_map(var!(compile)) and is_map(var!(runtime)) and is_function(fun, 0) do
+      unquote(compile_start_callbacks(instrumenters, event))
+      start = :erlang.monotonic_time()
+
+      try do
+        fun.()
+      after
+        var!(diff) = :erlang.monotonic_time() - start
+        unquote(compile_stop_callbacks(instrumenters, event))
+      end
+    end
+  end
+
+  # Catch-all clause
+  def instrument(event, compile, runtime, fun)
+      when is_atom(event) and is_map(compile) and is_map(runtime) and is_function(fun, 0) do
+    fun.()
+  end
+
+  ## Private Functions
+
+  defp form_fa({name, arity}), do: Atom.to_string(name) <> "/" <> Integer.to_string(arity)
+  defp form_fa(nil), do: nil
+
+  # Strips a `Macro.Env` struct, leaving only interesting compile-time metadata.
+  @doc false
+  @spec strip_caller(Macro.Env.t) :: %{
+                                       optional(:application) => atom,
+                                       required(:file) => String.t,
+                                       required(:line) => non_neg_integer,
+                                       required(:function) => String.t | nil,
+                                       required(:module) => module
+                                     }
+  def strip_caller(%Macro.Env{module: mod, function: fun, file: file, line: line}) do
+    caller = %{module: mod, function: form_fa(fun), file: file, line: line}
+
+    if app = Application.get_env(:logger, :compile_time_application) do
+      Map.put(caller, :application, app)
+    else
+      caller
+    end
+  end
+end

--- a/lib/calcinator/instrument.ex
+++ b/lib/calcinator/instrument.ex
@@ -120,6 +120,21 @@ defmodule Calcinator.Instrument do
 
       authorization_module.can?(subject, :delete, %ecto_schema_module{})
 
+  #### `:index`
+
+  There is one call to authorize `:index`.
+
+      calcinator_can(:start,
+                     compile_metadata :: %{module: module, function: String.t, file: String.t, line: non_neg_integer},
+                     runtime_metdata :: %{action: :index
+                                          calcinator: %Calcinator{
+                                            authorizaton_module: module
+                                            ecto_schema_module: ecto_schema_module
+                                          },
+                                          target: ecto_schema_module})
+
+      authorization_module.can?(subject, :index, ecto_schema_module)
+
   #### `:show`
 
   ##### `Calcinator.get_related_resource/3`

--- a/lib/calcinator/instrument.ex
+++ b/lib/calcinator/instrument.ex
@@ -68,6 +68,14 @@ defmodule Calcinator.Instrument do
 
   ### Events
 
+  #### `:alembic`
+
+  When `Calcinator` calls `Alembic.Document.from_json/2`
+
+      alembic(:start
+              compile_metadata :: %{module: module, function: String.t, file: String.t, line: non_neg_integer},
+              runtime_metdata :: %{action: :create | :update, params: params})
+
   #### `:calcinator_authorization`
 
   `:calcinator_authorization` occurs around calls to the `authorization_module.can?/3` in `Calcinator.can?/3` to measure how long

--- a/lib/calcinator/instrument.ex
+++ b/lib/calcinator/instrument.ex
@@ -111,7 +111,7 @@ defmodule Calcinator.Instrument do
 
       calcinator_can(:start,
                      compile_metadata :: %{module: module, function: String.t, file: String.t, line: non_neg_integer},
-                     runtime_metdata :: %{action: :create
+                     runtime_metdata :: %{action: :delete
                                           calcinator: %Calcinator{
                                             authorizaton_module: module
                                             ecto_schema_module: ecto_schema_module
@@ -140,11 +140,11 @@ defmodule Calcinator.Instrument do
   ##### `Calcinator.get_related_resource/3`
 
   There is not a special `action` for authorizing `Calcinator.get_related_resource/3`, instead the `source` is authorized
-  for `:show`.  **NOTE: This is the same pattern as for `Calcinator.show/3`.**
+  for `:show`.  **NOTE: This is the same pattern as for `Calcinator.show/2` and `Calcinator.show_relationship/3`.**
 
       calcinator_can(:start,
                      compile_metadata :: %{module: module, function: String.t, file: String.t, line: non_neg_integer},
-                     runtime_metdata :: %{action: :create
+                     runtime_metdata :: %{action: :show
                                           calcinator: %Calcinator{
                                             authorizaton_module: module
                                             ecto_schema_module: ecto_schema_module
@@ -153,11 +153,12 @@ defmodule Calcinator.Instrument do
 
       authorization_module.can?(subject, :show, %ecto_schema_module{})
 
-  If the `source` can be shown, then its checked if the `related` can be show in an association ascent under `source`
+  If the `source` can be shown, then its checked if the `related` can be show in an association ascent under `source`.
+  **NOTE: This is the same pattern as for `Calcinator.show_relationship/3`.**
 
      calcinator_can(:start,
                     compile_metadata :: %{module: module, function: String.t, file: String.t, line: non_neg_integer},
-                    runtime_metdata :: %{action: :create
+                    runtime_metdata :: %{action: :show
                                          calcinator: %Calcinator{
                                            authorizaton_module: module
                                            ecto_schema_module: ecto_schema_module
@@ -169,11 +170,11 @@ defmodule Calcinator.Instrument do
   ##### `Calcinator.show/2`
 
   The primary data is authorized for `:show`. **NOTE: This is the same pattern as the authorization to `:show` the
-  `source` for `Calcinator.get_related_resource/3`.
+  `source` for `Calcinator.get_related_resource/3` and `Calcinator.show_relationship/3`.
 
       calcinator_can(:start,
                      compile_metadata :: %{module: module, function: String.t, file: String.t, line: non_neg_integer},
-                     runtime_metdata :: %{action: :create
+                     runtime_metdata :: %{action: :show
                                           calcinator: %Calcinator{
                                             authorizaton_module: module
                                             ecto_schema_module: ecto_schema_module
@@ -181,6 +182,36 @@ defmodule Calcinator.Instrument do
                                           target: %ecto_schema_module{}})
 
       authorization_module.can?(subject, :show, %ecto_schema_module{})
+
+  ##### `Calcinator.show_relationship/3`
+
+  There is not a special `action` for authorizing `Calcinator.show_relationship/3`, instead the `source` is authorized
+  for `:show`.  **NOTE: This is the same pattern as for `Calcinator.show/2` and `Calcinator.get_related_resource/3`.**
+
+      calcinator_can(:start,
+                     compile_metadata :: %{module: module, function: String.t, file: String.t, line: non_neg_integer},
+                     runtime_metdata :: %{action: :show
+                                          calcinator: %Calcinator{
+                                            authorizaton_module: module
+                                            ecto_schema_module: ecto_schema_module
+                                          },
+                                          target: %ecto_schema_module{}})
+
+      authorization_module.can?(subject, :show, %ecto_schema_module{})
+
+  If the `source` can be shown, then its checked if the `related` can be show in an association ascent under `source`.
+  **NOTE: This is the same pattern as for `Calcinator.get_related_resource/3`.**
+
+     calcinator_can(:start,
+                    compile_metadata :: %{module: module, function: String.t, file: String.t, line: non_neg_integer},
+                    runtime_metdata :: %{action: :show
+                                         calcinator: %Calcinator{
+                                           authorizaton_module: module
+                                           ecto_schema_module: ecto_schema_module
+                                         },
+                                         target: [%related_ecto_schema_module{}, %ecto_schema_module{}])
+
+     authorization_module.can?(subject, :show, [%related_ecto_schema_module{}, %ecto_schema_module{}])
 
   """
 

--- a/lib/calcinator/instrument.ex
+++ b/lib/calcinator/instrument.ex
@@ -140,7 +140,7 @@ defmodule Calcinator.Instrument do
   ##### `Calcinator.get_related_resource/3`
 
   There is not a special `action` for authorizing `Calcinator.get_related_resource/3`, instead the `source` is authorized
-  for `:show`.
+  for `:show`.  **NOTE: This is the same pattern as for `Calcinator.show/3`.**
 
       calcinator_can(:start,
                      compile_metadata :: %{module: module, function: String.t, file: String.t, line: non_neg_integer},
@@ -151,7 +151,7 @@ defmodule Calcinator.Instrument do
                                           },
                                           target: %ecto_schema_module{}})
 
-      authorization_module.can?(subejct, :show, %ecto_schema_module{})
+      authorization_module.can?(subject, :show, %ecto_schema_module{})
 
   If the `source` can be shown, then its checked if the `related` can be show in an association ascent under `source`
 
@@ -165,6 +165,22 @@ defmodule Calcinator.Instrument do
                                          target: [%related_ecto_schema_module{}, %ecto_schema_module{}])
 
      authorization_module.can?(subject, :show, [%related_ecto_schema_module{}, %ecto_schema_module{}])
+
+  ##### `Calcinator.show/2`
+
+  The primary data is authorized for `:show`. **NOTE: This is the same pattern as the authorization to `:show` the
+  `source` for `Calcinator.get_related_resource/3`.
+
+      calcinator_can(:start,
+                     compile_metadata :: %{module: module, function: String.t, file: String.t, line: non_neg_integer},
+                     runtime_metdata :: %{action: :create
+                                          calcinator: %Calcinator{
+                                            authorizaton_module: module
+                                            ecto_schema_module: ecto_schema_module
+                                          },
+                                          target: %ecto_schema_module{}})
+
+      authorization_module.can?(subject, :show, %ecto_schema_module{})
 
   """
 

--- a/lib/calcinator/instrument.ex
+++ b/lib/calcinator/instrument.ex
@@ -120,6 +120,37 @@ defmodule Calcinator.Instrument do
 
       authorization_module.can?(subject, :delete, %ecto_schema_module{})
 
+  #### `:show`
+
+  ##### `Calcinator.get_related_resource/3`
+
+  There is not a special `action` for authorizing `Calcinator.get_related_resource/3`, instead the `source` is authorized
+  for `:show`.
+
+      calcinator_can(:start,
+                     compile_metadata :: %{module: module, function: String.t, file: String.t, line: non_neg_integer},
+                     runtime_metdata :: %{action: :create
+                                          calcinator: %Calcinator{
+                                            authorizaton_module: module
+                                            ecto_schema_module: ecto_schema_module
+                                          },
+                                          target: %ecto_schema_module{}})
+
+      authorization_module.can?(subejct, :show, %ecto_schema_module{})
+
+  If the `source` can be shown, then its checked if the `related` can be show in an association ascent under `source`
+
+     calcinator_can(:start,
+                    compile_metadata :: %{module: module, function: String.t, file: String.t, line: non_neg_integer},
+                    runtime_metdata :: %{action: :create
+                                         calcinator: %Calcinator{
+                                           authorizaton_module: module
+                                           ecto_schema_module: ecto_schema_module
+                                         },
+                                         target: [%related_ecto_schema_module{}, %ecto_schema_module{}])
+
+     authorization_module.can?(subject, :show, [%related_ecto_schema_module{}, %ecto_schema_module{}])
+
   """
 
   require Logger

--- a/lib/calcinator/instrument.ex
+++ b/lib/calcinator/instrument.ex
@@ -287,6 +287,76 @@ defmodule Calcinator.Instrument do
 
       authorization_module.can?(subject, :update, %Ecto.Changeset{data: %ecto_schema_module{}})
 
+  #### `:calcinator_resources`
+
+  The `:calcinator_resources` event is fired around any `resources_module` call by `Calcinator`.
+
+  The general format has the `args` passed to the `Calcinator.Resources.t` `callback`
+
+      calcinator_view(:start,
+                      compile_metadata :: %{module: module, function: String.t, file: String.t, line: non_neg_integer},
+                      runtime_metadata :: %{args: args,
+                                            calcinator: %Calcinator{resources_module: Calcinator.Resources.t},
+                                            callback: atom})
+
+  ##### `Calcinator.Resources.allow_sandbox_access/1`
+
+      calcinator_view(:start,
+                      compile_metadata :: %{module: module, function: String.t, file: String.t, line: non_neg_integer},
+                      runtime_metadata :: %{args: [beam],
+                                            calcinator: %Calcinator{resources_module: Calcinator.Resources.t},
+                                            callback: :allow_sandbox_access})
+
+  The only argument is the opaque `beam` data structure that is used to allow sandbox access.
+
+  ##### `Calcinator.Resources.delete/2`, `Calcinator.Resources.insert/2`, and `Calcinator.Resources.update/2`
+
+      calcinator_resources(:start,
+                           compile_metadata ::
+                             %{module: module, function: String.t, file: String.t, line: non_neg_integer},
+                           runtime_metadata :: %{args: [changeset, query_options],
+                                                 calcinator: %Calcinator{resources_module: Calcinator.Resources.t},
+                                                 callback: :delete | :insert | :update})
+
+  `Calcinator.Resources.delete/2`, `Calcinator.Resources.insert/2`, and `Calcinator.Resources.update/2` all take 2
+  arguments:
+
+  1. `changeset` - `Ecto.Changeset.t`
+  2. `query_options` - `Calcinator.Resoures.query_options`
+
+  ##### `Calcinator.Resources.get/2`
+
+      calcinator_view(:start,
+                      compile_metadata :: %{module: module, function: String.t, file: String.t, line: non_neg_integer},
+                      runtime_metadata :: %{args: [id, query_options],
+                                            calcinator: %Calcinator{resources_module: Calcinator.Resources.t},
+                                            callback: :get})
+
+  Arguments
+
+  1. `id` - ID of resource to lookup (`String.t` or `non_neg_integer`)
+  2. `query_options` - `Calcinator.Resoures.query_options`
+
+  ##### `Calcinator.Resources.list/1`
+
+      calcinator_view(:start,
+                      compile_metadata :: %{module: module, function: String.t, file: String.t, line: non_neg_integer},
+                      runtime_metadata :: %{args: [query_options],
+                                            calcinator: %Calcinator{resources_module: Calcinator.Resources.t},
+                                            callback: :list})
+
+  Arguments
+
+  1. `query_options` - `Calcinator.Resoures.query_options`
+
+  ##### `Calcinator.Resources.sandboxed?/0`
+
+      calcinator_view(:start,
+                      compile_metadata :: %{module: module, function: String.t, file: String.t, line: non_neg_integer},
+                      runtime_metadata :: %{args: [],
+                                            calcinator: %Calcinator{resources_module: Calcinator.Resources.t},
+                                            callback: :sandboxed?})
+
   #### `:calcinator_view`
 
   `calcinator` splits rendering into calling the `view_module` and then encoding to the underlying transport.  Only

--- a/lib/calcinator/instrument.ex
+++ b/lib/calcinator/instrument.ex
@@ -68,9 +68,9 @@ defmodule Calcinator.Instrument do
 
   ### Events
 
-  ### `:calcinator_can`
+  ### `:calcinator_authorization`
 
-  `:calcinator_can` occurs around calls to the `authorization_module.can?/3` in `Calcinator.can?/3` to measure how long
+  `:calcinator_authorization` occurs around calls to the `authorization_module.can?/3` in `Calcinator.can?/3` to measure how long
   it takes to authorize actions on the primary target.
 
   #### `:create`
@@ -80,14 +80,15 @@ defmodule Calcinator.Instrument do
   The first call will use the `ecto_schema_module` as the `target` to check if `ecto_schema_module` structs can be
   created in general by the `subject`.
 
-      calcinator_can(:start,
-                     compile_metadata :: %{module: module, function: String.t, file: String.t, line: non_neg_integer},
-                     runtime_metdata :: %{action: :create
-                                          calcinator: %Calcinator{
-                                            authorizaton_module: module
-                                            ecto_schema_module: ecto_schema_module
-                                          },
-                                          target: ecto_schema_module})
+      calcinator_authorization(:start,
+                               compile_metadata ::
+                                 %{module: module, function: String.t, file: String.t, line: non_neg_integer},
+                               runtime_metdata :: %{action: :create
+                                                    calcinator: %Calcinator{
+                                                      authorizaton_module: module
+                                                      ecto_schema_module: ecto_schema_module
+                                                    },
+                                                    target: ecto_schema_module})
 
   Before
 
@@ -96,14 +97,15 @@ defmodule Calcinator.Instrument do
   If the `subject` can create `ecto_schema_module` structs in general, then a second call will check if the specific
   `Ecto.Changeset.t` can be created.
 
-      calcinator_can(:start,
-                     compile_metadata :: %{module: module, function: String.t, file: String.t, line: non_neg_integer},
-                     runtime_metadata :: %{action: :create,
-                                           calcinator: %Calcinator{
-                                             authorizaton_module: module
-                                             ecto_schema_module: ecto_schema_module
-                                           },
-                                           target: %Ecto.Changeset{data: %ecto_schema_module{}}})
+      calcinator_authorization(:start,
+                               compile_metadata ::
+                                 %{module: module, function: String.t, file: String.t, line: non_neg_integer},
+                               runtime_metadata :: %{action: :create,
+                                                     calcinator: %Calcinator{
+                                                       authorizaton_module: module
+                                                       ecto_schema_module: ecto_schema_module
+                                                     },
+                                                     target: %Ecto.Changeset{data: %ecto_schema_module{}}})
 
   Before
 
@@ -113,14 +115,15 @@ defmodule Calcinator.Instrument do
 
   There is only one call to authorize `:delete`.
 
-      calcinator_can(:start,
-                     compile_metadata :: %{module: module, function: String.t, file: String.t, line: non_neg_integer},
-                     runtime_metdata :: %{action: :delete
-                                          calcinator: %Calcinator{
-                                            authorizaton_module: module
-                                            ecto_schema_module: ecto_schema_module
-                                          },
-                                          target: %ecto_schema_module{}})
+      calcinator_authorization(:start,
+                               compile_metadata ::
+                                 %{module: module, function: String.t, file: String.t, line: non_neg_integer},
+                               runtime_metdata :: %{action: :delete
+                                                  calcinator: %Calcinator{
+                                                    authorizaton_module: module
+                                                    ecto_schema_module: ecto_schema_module
+                                                  },
+                                                  target: %ecto_schema_module{}})
 
       authorization_module.can?(subject, :delete, %ecto_schema_module{})
 
@@ -128,14 +131,15 @@ defmodule Calcinator.Instrument do
 
   There is one call to authorize `:index`.
 
-      calcinator_can(:start,
-                     compile_metadata :: %{module: module, function: String.t, file: String.t, line: non_neg_integer},
-                     runtime_metdata :: %{action: :index
-                                          calcinator: %Calcinator{
-                                            authorizaton_module: module
-                                            ecto_schema_module: ecto_schema_module
-                                          },
-                                          target: ecto_schema_module})
+      calcinator_authorization(:start,
+                               compile_metadata ::
+                                 %{module: module, function: String.t, file: String.t, line: non_neg_integer},
+                               runtime_metdata :: %{action: :index
+                                                    calcinator: %Calcinator{
+                                                      authorizaton_module: module
+                                                      ecto_schema_module: ecto_schema_module
+                                                    },
+                                                    target: ecto_schema_module})
 
   Before
 
@@ -151,14 +155,15 @@ defmodule Calcinator.Instrument do
   *NOTE: This is the same pattern as for `Calcinator.show/2`, `Calcinator.show_relationship/3`, and
   `Calcinator.update/2`.*
 
-      calcinator_can(:start,
-                     compile_metadata :: %{module: module, function: String.t, file: String.t, line: non_neg_integer},
-                     runtime_metdata :: %{action: :show
-                                          calcinator: %Calcinator{
-                                            authorizaton_module: module
-                                            ecto_schema_module: ecto_schema_module
-                                          },
-                                          target: %ecto_schema_module{}})
+      calcinator_authorization(:start,
+                               compile_metadata ::
+                                 %{module: module, function: String.t, file: String.t, line: non_neg_integer},
+                               runtime_metdata :: %{action: :show
+                                                    calcinator: %Calcinator{
+                                                      authorizaton_module: module
+                                                      ecto_schema_module: ecto_schema_module
+                                                    },
+                                                    target: %ecto_schema_module{}})
 
   Before
 
@@ -168,14 +173,15 @@ defmodule Calcinator.Instrument do
 
   *NOTE: This is the same pattern as for `Calcinator.show_relationship/3`.*
 
-      calcinator_can(:start,
-                     compile_metadata :: %{module: module, function: String.t, file: String.t, line: non_neg_integer},
-                     runtime_metdata :: %{action: :show
-                                          calcinator: %Calcinator{
-                                            authorizaton_module: module
-                                            ecto_schema_module: ecto_schema_module
-                                          },
-                                          target: [%related_ecto_schema_module{}, %ecto_schema_module{}])
+      calcinator_authorization(:start,
+                               compile_metadata ::
+                                 %{module: module, function: String.t, file: String.t, line: non_neg_integer},
+                               runtime_metdata :: %{action: :show
+                                                    calcinator: %Calcinator{
+                                                      authorizaton_module: module
+                                                      ecto_schema_module: ecto_schema_module
+                                                    },
+                                                    target: [%related_ecto_schema_module{}, %ecto_schema_module{}])
 
   Before
 
@@ -188,14 +194,15 @@ defmodule Calcinator.Instrument do
   *NOTE: This is the same pattern as the authorization to `:show` the `source` for `Calcinator.get_related_resource/3`,
   `Calcinator.show_relationship/3`, and `Calcinator.update/2`.*
 
-      calcinator_can(:start,
-                     compile_metadata :: %{module: module, function: String.t, file: String.t, line: non_neg_integer},
-                     runtime_metdata :: %{action: :show
-                                          calcinator: %Calcinator{
-                                            authorizaton_module: module
-                                            ecto_schema_module: ecto_schema_module
-                                          },
-                                          target: %ecto_schema_module{}})
+      calcinator_authorization(:start,
+                               compile_metadata ::
+                                 %{module: module, function: String.t, file: String.t, line: non_neg_integer},
+                               runtime_metdata :: %{action: :show
+                                                    calcinator: %Calcinator{
+                                                      authorizaton_module: module
+                                                      ecto_schema_module: ecto_schema_module
+                                                    },
+                                                    target: %ecto_schema_module{}})
 
   Before
 
@@ -209,14 +216,15 @@ defmodule Calcinator.Instrument do
   *NOTE: This is the same pattern as for `Calcinator.show/2`, `Calcinator.get_related_resource/3`, and
   `Calcinator.update/2`.*
 
-      calcinator_can(:start,
-                     compile_metadata :: %{module: module, function: String.t, file: String.t, line: non_neg_integer},
-                     runtime_metdata :: %{action: :show
-                                          calcinator: %Calcinator{
-                                            authorizaton_module: module
-                                            ecto_schema_module: ecto_schema_module
-                                          },
-                                          target: %ecto_schema_module{}})
+      calcinator_authorization(:start,
+                               compile_metadata ::
+                                 %{module: module, function: String.t, file: String.t, line: non_neg_integer},
+                               runtime_metdata :: %{action: :show
+                                                    calcinator: %Calcinator{
+                                                      authorizaton_module: module
+                                                      ecto_schema_module: ecto_schema_module
+                                                    },
+                                                    target: %ecto_schema_module{}})
 
   Before
 
@@ -226,14 +234,15 @@ defmodule Calcinator.Instrument do
 
   *NOTE: This is the same pattern as for `Calcinator.get_related_resource/3`.*
 
-      calcinator_can(:start,
-                     compile_metadata :: %{module: module, function: String.t, file: String.t, line: non_neg_integer},
-                     runtime_metdata :: %{action: :show
-                                          calcinator: %Calcinator{
-                                            authorizaton_module: module
-                                            ecto_schema_module: ecto_schema_module
-                                          },
-                                          target: [%related_ecto_schema_module{}, %ecto_schema_module{}])
+      calcinator_authorization(:start,
+                               compile_metadata ::
+                                 %{module: module, function: String.t, file: String.t, line: non_neg_integer},
+                               runtime_metdata :: %{action: :show
+                                                    calcinator: %Calcinator{
+                                                      authorizaton_module: module
+                                                      ecto_schema_module: ecto_schema_module
+                                                    },
+                                                    target: [%related_ecto_schema_module{}, %ecto_schema_module{}])
 
   Before
 
@@ -244,14 +253,15 @@ defmodule Calcinator.Instrument do
   Before a `target` can be updated, it is checked that `subject` can `:show` the target. **NOTE: This is the same
   pattern as for `Calcinator.show/2`, `Calcinator.get_related_resource/3`, and `Calcinator.show_relatonship/3`.**
 
-      calcinator_can(:start,
-                     compile_metadata :: %{module: module, function: String.t, file: String.t, line: non_neg_integer},
-                     runtime_metdata :: %{action: :show
-                                          calcinator: %Calcinator{
-                                            authorizaton_module: module
-                                            ecto_schema_module: ecto_schema_module
-                                          },
-                                          target: %ecto_schema_module{}})
+      calcinator_authorization(:start,
+                               compile_metadata ::
+                                 %{module: module, function: String.t, file: String.t, line: non_neg_integer},
+                               runtime_metdata :: %{action: :show
+                                                    calcinator: %Calcinator{
+                                                      authorizaton_module: module
+                                                      ecto_schema_module: ecto_schema_module
+                                                    },
+                                                    target: %ecto_schema_module{}})
 
   Before
 
@@ -263,14 +273,15 @@ defmodule Calcinator.Instrument do
 
   If a `target` is authorized for `:show`, it is checked if the `subject` can update the `Ecto.Changeset.t`.
 
-      calcinator_can(:start,
-                     compile_metadata :: %{module: module, function: String.t, file: String.t, line: non_neg_integer},
-                     runtime_metdata :: %{action: :update
-                                          calcinator: %Calcinator{
-                                            authorizaton_module: module
-                                            ecto_schema_module: ecto_schema_module
-                                          },
-                                          target: %Ecto.Changeset{data: %ecto_schema_module{}}})
+      calcinator_authorization(:start,
+                               compile_metadata ::
+                                 %{module: module, function: String.t, file: String.t, line: non_neg_integer},
+                               runtime_metdata :: %{action: :update
+                                                    calcinator: %Calcinator{
+                                                      authorizaton_module: module
+                                                      ecto_schema_module: ecto_schema_module
+                                                    },
+                                                    target: %Ecto.Changeset{data: %ecto_schema_module{}}})
 
   Before
 
@@ -296,7 +307,7 @@ defmodule Calcinator.Instrument do
 
   ### Examples
 
-      instrument :calcinator_can, %{action: action, calcinator: calcinator, target: target}, fn ->
+      instrument :calcinator_authorization, %{action: action, calcinator: calcinator, target: target}, fn ->
         ...
       end
 

--- a/lib/calcinator/instrument.ex
+++ b/lib/calcinator/instrument.ex
@@ -68,12 +68,12 @@ defmodule Calcinator.Instrument do
 
   ### Events
 
-  ### `:calcinator_authorization`
+  #### `:calcinator_authorization`
 
   `:calcinator_authorization` occurs around calls to the `authorization_module.can?/3` in `Calcinator.can?/3` to measure how long
   it takes to authorize actions on the primary target.
 
-  #### `:create`
+  ##### `:create`
 
   There are two calls to authorize `:create`.
 
@@ -111,7 +111,7 @@ defmodule Calcinator.Instrument do
 
       authorization_module.can?(subject, :create, %Ecto.Changeset{data: %ecto_schema_module{}})
 
-  #### `:delete`
+  ##### `:delete`
 
   There is only one call to authorize `:delete`.
 
@@ -127,7 +127,7 @@ defmodule Calcinator.Instrument do
 
       authorization_module.can?(subject, :delete, %ecto_schema_module{})
 
-  #### `:index`
+  ##### `:index`
 
   There is one call to authorize `:index`.
 
@@ -145,9 +145,9 @@ defmodule Calcinator.Instrument do
 
       authorization_module.can?(subject, :index, ecto_schema_module)
 
-  #### `:show`
+  ##### `:show`
 
-  ##### `Calcinator.get_related_resource/3`
+  ###### `Calcinator.get_related_resource/3`
 
   There is not a special `action` for authorizing `Calcinator.get_related_resource/3`, instead the `source` is authorized
   for `:show`.
@@ -187,7 +187,7 @@ defmodule Calcinator.Instrument do
 
       authorization_module.can?(subject, :show, [%related_ecto_schema_module{}, %ecto_schema_module{}])
 
-  ##### `Calcinator.show/2`
+  ###### `Calcinator.show/2`
 
   The primary data is authorized for `:show`.
 
@@ -208,7 +208,7 @@ defmodule Calcinator.Instrument do
 
       authorization_module.can?(subject, :show, %ecto_schema_module{})
 
-  ##### `Calcinator.show_relationship/3`
+  ###### `Calcinator.show_relationship/3`
 
   There is not a special `action` for authorizing `Calcinator.show_relationship/3`, instead the `source` is authorized
   for `:show`.
@@ -248,7 +248,7 @@ defmodule Calcinator.Instrument do
 
       authorization_module.can?(subject, :show, [%related_ecto_schema_module{}, %ecto_schema_module{}])
 
-  ##### `Calcinator.update/3`
+  ###### `Calcinator.update/3`
 
   Before a `target` can be updated, it is checked that `subject` can `:show` the target. **NOTE: This is the same
   pattern as for `Calcinator.show/2`, `Calcinator.get_related_resource/3`, and `Calcinator.show_relatonship/3`.**
@@ -267,9 +267,9 @@ defmodule Calcinator.Instrument do
 
       authorization_module.can?(subject, :show, %ecto_schema_module{})
 
-  #### `:update`
+  ##### `:update`
 
-  ##### `Calcinator.update/3`
+  ###### `Calcinator.update/3`
 
   If a `target` is authorized for `:show`, it is checked if the `subject` can update the `Ecto.Changeset.t`.
 

--- a/lib/calcinator/instrumenters.ex
+++ b/lib/calcinator/instrumenters.ex
@@ -1,0 +1,99 @@
+defmodule Calcinator.Instrumenters do
+  @moduledoc false
+
+  # Constants
+
+  # This is the arity that event callbacks in the instrumenter modules must
+  # have.
+  @event_callback_arity 3
+
+  # Functions
+
+  # Reads a list of the instrumenters from the config of `:calcinator` and finds all events in those instrumenters. The
+  # return value is a list of `{event, instrumenters}` tuples, one for each event defined by any instrumenters (with no
+  # duplicated events); `instrumenters` is the list of instrumenters interested in `event`.
+  @doc false
+  def app_instrumenters do
+    instrumenters = Application.get_env(:calcinator, :instrumenters, [])
+
+    unless is_list(instrumenters) and Enum.all?(instrumenters, &is_atom/1) do
+      raise ":instrumenters must be a list of instrumenter modules"
+    end
+
+    events_to_instrumenters(instrumenters)
+  end
+
+  # Returns the AST for all the calls to the "start event" callbacks in the given
+  # list of `instrumenters`.
+  # Each function call looks like this:
+  #
+  #     res0 = Instr0.my_event(:start, compile, runtime)
+  #
+  @doc false
+  @spec compile_start_callbacks([module], term) :: Macro.t
+  def compile_start_callbacks(instrumenters, event) do
+    Enum.map Enum.with_index(instrumenters), fn {inst, index} ->
+      error_prefix = "Instrumenter #{inspect inst}.#{event}/3 failed.\n"
+
+      quote do
+        unquote(build_result_variable(index)) =
+          try do
+            unquote(inst).unquote(event)(:start, var!(compile), var!(runtime))
+          catch
+            kind, error ->
+              Logger.error unquote(error_prefix) <> Exception.format(kind, error)
+          end
+      end
+    end
+  end
+
+  # Returns the AST for all the calls to the "stop event" callbacks in the given
+  # list of `instrumenters`.
+  # Each function call looks like this:
+  #
+  #     Instr0.my_event(:stop, diff, res0)
+  #
+  @doc false
+  @spec compile_stop_callbacks([module], term) :: Macro.t
+  def compile_stop_callbacks(instrumenters, event) do
+    Enum.map Enum.with_index(instrumenters), fn {inst, index} ->
+      error_prefix = "Instrumenter #{inspect inst}.#{event}/3 failed.\n"
+
+      quote do
+        try do
+          unquote(inst).unquote(event)(:stop, var!(diff), unquote(build_result_variable(index)))
+        catch
+          kind, error ->
+            Logger.error unquote(error_prefix) <> Exception.format(kind, error)
+        end
+      end
+    end
+  end
+
+  ## Private Functions
+
+  defp build_result_variable(index) when is_integer(index) do
+    "res#{index}" |> String.to_atom() |> Macro.var(nil)
+  end
+
+  # Takes a list of instrumenter modules and returns a list of `{event,
+  # instrumenters}` tuples where each tuple represents an event and all the
+  # modules interested in that event.
+  defp events_to_instrumenters(instrumenters) do
+    instrumenters                                              # [Ins1, Ins2, ...]
+    |> instrumenters_and_events()                              # [{Ins1, e1}, {Ins2, e1}, ...]
+    |> Enum.group_by(fn {_inst, e} -> e end)                   # %{e1 => [{Ins1, e1}, ...], ...}
+    |> Enum.map(fn {e, insts} -> {e, strip_events(insts)} end) # [{e1, [Ins1, Ins2]}, ...]
+  end
+
+  defp instrumenters_and_events(instrumenters) do
+    # We're only interested in functions (events) with the given arity.
+    for inst <- instrumenters,
+        {event, @event_callback_arity} <- inst.__info__(:functions),
+        do: {inst, event}
+  end
+
+  defp strip_events(instrumenters) do
+    for {inst, _evt} <- instrumenters, do: inst
+  end
+end

--- a/lib/calcinator/pry_in/instrumenter.ex
+++ b/lib/calcinator/pry_in/instrumenter.ex
@@ -68,7 +68,7 @@ if Code.ensure_loaded?(PryIn) do
           function: function,
           key: "calcinator_can_#{action}",
           line: line,
-          module: module,
+          module: module_name(module),
           pid: inspect(self())
         ]
         InteractionStore.add_custom_metric(self(), data)

--- a/lib/calcinator/pry_in/instrumenter.ex
+++ b/lib/calcinator/pry_in/instrumenter.ex
@@ -46,7 +46,7 @@ if Code.ensure_loaded?(PryIn) do
     def calcinator_authorization(
           :stop,
           time_diff,
-          %{
+          metadata = %{
             action: action,
             calcinator: %{
               authorization_module: authorization_module,
@@ -75,7 +75,13 @@ if Code.ensure_loaded?(PryIn) do
           module: module_name(module),
           pid: inspect(self())
         ]
-        InteractionStore.add_custom_metric(self(), data)
+
+        full_data = case Map.fetch(metadata, :offset) do
+          {:ok, offset} -> Keyword.put(data, :offset, offset)
+          :error -> data
+        end
+
+        InteractionStore.add_custom_metric(self(), full_data)
       end
     end
 

--- a/lib/calcinator/pry_in/instrumenter.ex
+++ b/lib/calcinator/pry_in/instrumenter.ex
@@ -1,0 +1,95 @@
+if Code.ensure_loaded?(PryIn) do
+  # Based on https://github.com/pryin-io/pryin/blob/9fec04d61a7b8d4ff337653294f13c4e345c7029/lib/pryin/instrumenter.ex
+  defmodule Calcinator.PryIn.Instrumenter do
+    @moduledoc """
+    Collects metrics about
+
+    * `Calcinator.can/3`
+
+    Activate via:
+
+    ```elixir
+    config :calcinator,
+           instrumenters: [Calcinator.PryIn.Instrumenter]
+    ```
+
+    """
+
+    import PryIn.{InteractionHelper, TimeHelper}
+
+    alias PryIn.InteractionStore
+
+    # Functions
+
+    ## Calcinator.Instrumenter event callbacks
+
+    @doc """
+    Collects metrics about `Calcinator.can/3` calls.
+
+    Metrics are only collected inside of tracked interactions
+    """
+
+    def calcinator_can(:start, %{file: file, function: function, line: line, module: module}, runtime_metadata) do
+      metadata = Map.merge(runtime_metadata, %{file: file, function: function, line: line, module: module})
+
+      if InteractionStore.has_pid?(self()) do
+        now = utc_unix_datetime()
+        offset = now - InteractionStore.get_field(self(), :start_time)
+        Map.put(metadata, :offset, offset)
+      else
+        metadata
+      end
+    end
+
+    def calcinator_can(
+          :stop,
+          time_diff,
+          %{
+            action: action,
+            calcinator: %{
+              authorization_module: authorization_module,
+              subject: subject
+            },
+            file: file,
+            function: function,
+            line: line,
+            module: module,
+            target: target
+          }
+        ) do
+      if InteractionStore.has_pid?(self()) do
+        target_prefix = "calcinator/can/actions/#{action}/targets/#{target_name(target)}"
+        InteractionStore.put_context(self(), "#{target_prefix}/subject", subject_name(subject))
+        InteractionStore.put_context(self(), "#{target_prefix}/authorization_module", module_name(authorization_module))
+
+        data = [
+          duration: System.convert_time_unit(time_diff, :native, :microseconds),
+          file: file,
+          function: function,
+          key: "calcinator_can_#{action}",
+          line: line,
+          module: module,
+          pid: inspect(self())
+        ]
+        InteractionStore.add_custom_metric(self(), data)
+      end
+    end
+
+    def calcinator_can(:stop, _time_diff, _), do: :ok
+
+    ## Private Functions
+
+    defp subject_name(nil), do: "nil"
+    defp subject_name(%subject_module{}), do: "%#{module_name(subject_module)}{}"
+
+    defp target_name(nil), do: "nil"
+    defp target_name(target) when is_atom(target), do: module_name(target)
+    defp target_name(%target_module{data: data}) when target_module == Ecto.Changeset do
+      "%#{module_name(target_module)}{data: #{target_name(data)}}"
+    end
+    defp target_name(%target_module{}), do: "%#{target_name(target_module)}{}"
+    defp target_name(association_ascent) when is_list(association_ascent) do
+      "[#{Enum.map_join(association_ascent, ", ", &target_name/1)}]"
+    end
+  end
+end

--- a/lib/calcinator/pry_in/instrumenter.ex
+++ b/lib/calcinator/pry_in/instrumenter.ex
@@ -7,6 +7,8 @@ if Code.ensure_loaded?(PryIn) do
     * `:calcinator_authorization`
       * `Calcinator.authorized/2`
       * `Calcinator.can/3`
+    * `:calcinator_view`
+      * `view_module` calls
 
     Activate via:
 
@@ -60,7 +62,7 @@ if Code.ensure_loaded?(PryIn) do
           }
         ) do
       if InteractionStore.has_pid?(self()) do
-        prefix = "calcinator/authorization/#{:erlang.unique_integer([:positive])}"
+        prefix = unique_prefix("calcinator_authorization")
         InteractionStore.put_context(self(), "#{prefix}/authorization_module", module_name(authorization_module))
         InteractionStore.put_context(self(), "#{prefix}/subject", subject_name(subject))
         InteractionStore.put_context(self(), "#{prefix}/action", to_string(action))
@@ -87,7 +89,117 @@ if Code.ensure_loaded?(PryIn) do
 
     def calcinator_authorization(:stop, _time_diff, _), do: :ok
 
+    def calcinator_view(:start, %{file: file, function: function, line: line, module: module}, runtime_metadata) do
+      metadata = Map.merge(runtime_metadata, %{file: file, function: function, line: line, module: module})
+
+      if InteractionStore.has_pid?(self()) do
+        now = utc_unix_datetime()
+        offset = now - InteractionStore.get_field(self(), :start_time)
+        Map.put(metadata, :offset, offset)
+      else
+        metadata
+      end
+    end
+
+    def calcinator_view(
+          :stop,
+          time_diff,
+          metadata = %{
+            args: args,
+            calcinator: %{
+              view_module: view_module
+            },
+            callback: callback,
+            file: file,
+            function: function,
+            line: line,
+            module: module
+          }
+        ) do
+      if InteractionStore.has_pid?(self()) do
+        put_calcinator_view_context(%{args: args, callback: callback, view_module: view_module})
+
+        data = [
+          duration: System.convert_time_unit(time_diff, :native, :microseconds),
+          file: file,
+          function: function,
+          key: "calcinator_view",
+          line: line,
+          module: module_name(module),
+          pid: inspect(self())
+        ]
+
+        full_data = case Map.fetch(metadata, :offset) do
+          {:ok, offset} -> Keyword.put(data, :offset, offset)
+          :error -> data
+        end
+
+        InteractionStore.add_custom_metric(self(), full_data)
+      end
+    end
+
+    #def calcinator_view(:stop, _time_diff, metadata), do: (IO.inspect(metadata); :ok)
+
     ## Private Functions
+
+    defp put_calcinator_view_context(
+           %{
+             args: [
+               related_resource,
+               %{
+                 related: %{resource: related_resource},
+                 source: %{association: source_association, resource: source_resource},
+                 subject: subject
+               }
+             ],
+             callback: callback,
+             prefix: prefix,
+             view_module: view_module
+           }
+         ) when callback in ~w(get_related_resource show_relationship)a do
+      put_calcinator_view_context(%{callback: callback, prefix: prefix, subject: subject, view_module: view_module})
+      InteractionStore.put_context(self(), "#{prefix}/source_resource", target_name(source_resource))
+      InteractionStore.put_context(self(), "#{prefix}/source_association", target_name(source_association))
+      InteractionStore.put_context(self(), "#{prefix}/related_resource", target_name(related_resource))
+    end
+
+    defp put_calcinator_view_context(
+           %{
+             args: [resources, %{subject: subject}],
+             callback: callback = :index,
+             prefix: prefix,
+             view_module: view_module
+           }
+         ) do
+      put_calcinator_view_context(%{callback: callback, prefix: prefix, subject: subject, view_module: view_module})
+      InteractionStore.put_context(self(), "#{prefix}/resources", target_name(resources))
+    end
+
+    defp put_calcinator_view_context(
+           %{
+             args: [resource, %{subject: subject}],
+             callback: callback = :show,
+             prefix: prefix,
+             view_module: view_module
+           }
+         ) do
+      put_calcinator_view_context(%{callback: callback, prefix: prefix, subject: subject, view_module: view_module})
+      InteractionStore.put_context(self(), "#{prefix}/resource", target_name(resource))
+    end
+
+    defp put_calcinator_view_context(
+           %{callback: callback, prefix: prefix, subject: subject, view_module: view_module}
+         ) do
+      InteractionStore.put_context(self(), "#{prefix}/view_module", module_name(view_module))
+      InteractionStore.put_context(self(), "#{prefix}/callback", to_string(callback))
+      InteractionStore.put_context(self(), "#{prefix}/subject", subject_name(subject))
+    end
+
+    defp put_calcinator_view_context(options) when is_map(options) do
+      options
+      |> Map.put(:prefix, unique_prefix("calcinator_view"))
+      |> put_calcinator_view_context()
+    end
 
     defp subject_name(nil), do: "nil"
     defp subject_name(%subject_module{}), do: "%#{module_name(subject_module)}{}"
@@ -100,6 +212,10 @@ if Code.ensure_loaded?(PryIn) do
     defp target_name(%target_module{}), do: "%#{target_name(target_module)}{}"
     defp target_name(association_ascent) when is_list(association_ascent) do
       "[#{Enum.map_join(association_ascent, ", ", &target_name/1)}]"
+    end
+
+    defp unique_prefix(prefix) do
+      "#{prefix}/#{:erlang.unique_integer([:positive])}"
     end
   end
 end

--- a/lib/calcinator/view.ex
+++ b/lib/calcinator/view.ex
@@ -27,6 +27,11 @@ defmodule Calcinator.View do
   """
   @type subject :: term
 
+  @typedoc """
+  A module that implements the `Calcinator.View` behaviour.
+  """
+  @type t :: module
+
   # Callbacks
 
   @doc """

--- a/mix.exs
+++ b/mix.exs
@@ -58,7 +58,9 @@ defmodule Calcinator.Mixfile do
     [applications: applications(env)]
   end
 
-  defp applications(:test), do: [:ecto, :ex_machina, :faker, :mix, :postgrex, :pryin | applications(:dev)]
+  defp applications(:test) do
+    [:ecto, :ex_machina, :faker, :mix, :phoenix, :plug, :postgrex, :pryin | applications(:dev)]
+  end
   defp applications(_), do: ~w(alembic ja_serializer logger)a
 
   # Dependencies can be Hex packages:

--- a/mix.exs
+++ b/mix.exs
@@ -42,6 +42,7 @@ defmodule Calcinator.Mixfile do
 
   defp aliases do
     [
+      "compile": "compile --warnings-as-errors",
       "test": ["calcinator.ecto.wait", "ecto.drop", "ecto.create --quiet", "ecto.migrate", "test"]
     ]
   end
@@ -57,7 +58,7 @@ defmodule Calcinator.Mixfile do
     [applications: applications(env)]
   end
 
-  defp applications(:test), do: [:ecto, :ex_machina, :faker, :mix, :postgrex | applications(:dev)]
+  defp applications(:test), do: [:ecto, :ex_machina, :faker, :mix, :postgrex, :pryin | applications(:dev)]
   defp applications(_), do: ~w(alembic ja_serializer logger)a
 
   # Dependencies can be Hex packages:
@@ -100,6 +101,8 @@ defmodule Calcinator.Mixfile do
       {:junit_formatter, "~> 1.0", only: :test},
       # Phoenix.Controller is used in Calcinator.Controller.Error
       {:phoenix, "~> 1.0", optional: true},
+      # Testing PryIn instrumenter
+      {:pryin, "~> 1.0", optional: true},
       # PostgreSQL DB access for Calcinator.Resources.Ecto.Repo.Repo used in tests
       {:postgrex, "~> 0.13.0", only: :test},
       # UUID for `errors` `0` `id` in `Calcinator.Controller.backing_store_error`

--- a/mix.exs
+++ b/mix.exs
@@ -29,7 +29,7 @@ defmodule Calcinator.Mixfile do
       test_coverage: [
         tool: ExCoveralls
       ],
-      version: "4.0.1"
+      version: "5.0.0"
     ]
   end
 
@@ -120,7 +120,7 @@ defmodule Calcinator.Mixfile do
 
   defp docs do
     [
-      extras: ~w(CHANGELOG.md CODE_OF_CONDUCT.md CONTRIBUTING.md LICENSE.md README.md)
+      extras: ~w(CHANGELOG.md CODE_OF_CONDUCT.md CONTRIBUTING.md LICENSE.md README.md UPGRADING.md)
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -12,7 +12,9 @@
   "ex_machina": {:hex, :ex_machina, "2.0.0", "ec284c6f57233729cea9319e083f66e613e82549f78eccdb2059aeba5d0df9f3", [:mix], [{:ecto, "~> 2.1", [hex: :ecto, repo: "hexpm", optional: true]}], "hexpm"},
   "excoveralls": {:hex, :excoveralls, "0.7.2", "f69ede8c122ccd3b60afc775348a53fc8c39fe4278aee2f538f0d81cc5e7ff3a", [:mix], [{:exjsx, ">= 3.0.0", [hex: :exjsx, repo: "hexpm", optional: false]}, {:hackney, ">= 0.12.0", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm"},
   "exjsx": {:hex, :exjsx, "4.0.0", "60548841e0212df401e38e63c0078ec57b33e7ea49b032c796ccad8cde794b5c", [:mix], [{:jsx, "~> 2.8.0", [hex: :jsx, repo: "hexpm", optional: false]}], "hexpm"},
+  "exprotobuf": {:hex, :exprotobuf, "1.2.9", "f3cac1b0d0444da3c72cdfe80e394d721275dc80b1d7703ead9dad9267e93822", [], [{:gpb, "~> 3.24", [hex: :gpb, repo: "hexpm", optional: false]}], "hexpm"},
   "faker": {:hex, :faker, "0.8.0", "91880d7aa0882ceca77849a28cecddaa337e274ac35197b65c7ad38cfa4517ab", [:mix], [], "hexpm"},
+  "gpb": {:hex, :gpb, "3.27.7", "08e5502d5c9964bb66f93f634fc284aa578834ac048a86b6e63803ae85c62b1f", [], [], "hexpm"},
   "hackney": {:hex, :hackney, "1.9.0", "51c506afc0a365868469dcfc79a9d0b94d896ec741cfd5bd338f49a5ec515bfe", [:rebar3], [{:certifi, "2.0.0", [hex: :certifi, repo: "hexpm", optional: false]}, {:idna, "5.1.0", [hex: :idna, repo: "hexpm", optional: false]}, {:metrics, "1.0.1", [hex: :metrics, repo: "hexpm", optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, repo: "hexpm", optional: false]}, {:ssl_verify_fun, "1.1.1", [hex: :ssl_verify_fun, repo: "hexpm", optional: false]}], "hexpm"},
   "idna": {:hex, :idna, "5.1.0", "d72b4effeb324ad5da3cab1767cb16b17939004e789d8c0ad5b70f3cea20c89a", [:rebar3], [{:unicode_util_compat, "0.3.1", [hex: :unicode_util_compat, repo: "hexpm", optional: false]}], "hexpm"},
   "inch_ex": {:hex, :inch_ex, "0.5.6", "418357418a553baa6d04eccd1b44171936817db61f4c0840112b420b8e378e67", [:mix], [{:poison, "~> 1.5 or ~> 2.0 or ~> 3.0", [hex: :poison, repo: "hexpm", optional: false]}], "hexpm"},
@@ -29,6 +31,8 @@
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
   "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], [], "hexpm"},
   "postgrex": {:hex, :postgrex, "0.13.3", "c277cfb2a9c5034d445a722494c13359e361d344ef6f25d604c2353185682bfc", [:mix], [{:connection, "~> 1.0", [hex: :connection, repo: "hexpm", optional: false]}, {:db_connection, "~> 1.1", [hex: :db_connection, repo: "hexpm", optional: false]}, {:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: false]}], "hexpm"},
+  "pryin": {:hex, :pryin, "1.4.0", "dc2a80f9139eb6482b2a3b71151adb0db53b4b38912c2b262224378b1926d906", [], [{:ecto, "~> 2.0", [hex: :ecto, repo: "hexpm", optional: true]}, {:exprotobuf, "~> 1.2", [hex: :exprotobuf, repo: "hexpm", optional: false]}, {:hackney, "~> 1.2", [hex: :hackney, repo: "hexpm", optional: false]}, {:phoenix, "~> 1.2", [hex: :phoenix, repo: "hexpm", optional: true]}, {:plug, "~> 1.0", [hex: :plug, repo: "hexpm", optional: true]}, {:recon, "~> 2.3", [hex: :recon, repo: "hexpm", optional: false]}], "hexpm"},
+  "recon": {:hex, :recon, "2.3.2", "4444c879be323b1b133eec5241cb84bd3821ea194c740d75617e106be4744318", [], [], "hexpm"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], [], "hexpm"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.3.1", "a1f612a7b512638634a603c8f401892afbf99b8ce93a45041f8aaca99cadb85e", [], [], "hexpm"},
   "uuid": {:hex, :uuid, "1.1.7", "007afd58273bc0bc7f849c3bdc763e2f8124e83b957e515368c498b641f7ab69", [:mix], [], "hexpm"}}

--- a/test/calcinator/controller_test.exs
+++ b/test/calcinator/controller_test.exs
@@ -1,10 +1,11 @@
 defmodule Calcinator.ControllerTest do
-  alias Calcinator.{Authorization.Cant, Meta.Beam, TestAuthorView, TestPostView}
+  alias Calcinator.{Authorization.Cant, TestAuthorView, TestPostView}
   alias Calcinator.Resources.{TestAuthor, TestPost, TestTag}
   alias Calcinator.Resources.Ecto.Repo.{Factory, TestAuthors, TestPosts}
   alias Calcinator.Resources.Ecto.Repo.Repo
   alias Plug.Conn
 
+  import Calcinator.Resources.Ecto.Repo.Repo.Case
   import ExUnit.CaptureLog
   import Plug.Conn, only: [put_req_header: 3]
   import Phoenix.ConnTest, only: [build_conn: 0, json_response: 2, response: 2]
@@ -1670,19 +1671,6 @@ defmodule Calcinator.ControllerTest do
              "status" => "403",
              "title" => "Forbidden"
            } in errors
-  end
-
-  defp checkout_meta do
-    :ok = Ecto.Adapters.SQL.Sandbox.checkout(Repo)
-
-    %{}
-    |> Beam.put(Repo)
-    |> Enum.into(
-         %{},
-         fn {key, value} ->
-           {to_string(key), value}
-         end
-       )
   end
 
   def resource_by_id_by_type(included) do

--- a/test/calcinator/pry_in/instrumenter_test.exs
+++ b/test/calcinator/pry_in/instrumenter_test.exs
@@ -68,7 +68,7 @@ defmodule Calcinator.PryIn.InstrumenterTest do
           assert %PryIn.Interaction.CustomMetric{
                    function: "can/3",
                    key: "calcinator_can_create",
-                   module: Calcinator,
+                   module: "Calcinator",
                  } = custom_metric
         end
       )
@@ -105,7 +105,7 @@ defmodule Calcinator.PryIn.InstrumenterTest do
           assert %PryIn.Interaction.CustomMetric{
                    function: "can/3",
                    key: "calcinator_can_delete",
-                   module: Calcinator,
+                   module: "Calcinator",
                  } = custom_metric
         end
       )
@@ -161,7 +161,7 @@ defmodule Calcinator.PryIn.InstrumenterTest do
           assert %PryIn.Interaction.CustomMetric{
                    function: "can/3",
                    key: "calcinator_can_show",
-                   module: Calcinator
+                   module: "Calcinator"
                  } = custom_metric
         end
       )
@@ -205,7 +205,7 @@ defmodule Calcinator.PryIn.InstrumenterTest do
           assert %PryIn.Interaction.CustomMetric{
                    function: "can/3",
                    key: "calcinator_can_index",
-                   module: Calcinator,
+                   module: "Calcinator",
                  } = custom_metric
         end
       )
@@ -242,7 +242,7 @@ defmodule Calcinator.PryIn.InstrumenterTest do
           assert %PryIn.Interaction.CustomMetric{
                    function: "can/3",
                    key: "calcinator_can_show",
-                   module: Calcinator,
+                   module: "Calcinator",
                  } = custom_metric
         end
       )
@@ -297,7 +297,7 @@ defmodule Calcinator.PryIn.InstrumenterTest do
           assert %PryIn.Interaction.CustomMetric{
                    function: "can/3",
                    key: "calcinator_can_show",
-                   module: Calcinator
+                   module: "Calcinator"
                  } = custom_metric
         end
       )
@@ -374,7 +374,7 @@ defmodule Calcinator.PryIn.InstrumenterTest do
       Enum.each(
         custom_metrics,
         fn custom_metric ->
-          assert %PryIn.Interaction.CustomMetric{function: "can/3", module: Calcinator} = custom_metric
+          assert %PryIn.Interaction.CustomMetric{function: "can/3", module: "Calcinator"} = custom_metric
         end
       )
     end

--- a/test/calcinator/pry_in/instrumenter_test.exs
+++ b/test/calcinator/pry_in/instrumenter_test.exs
@@ -338,5 +338,77 @@ defmodule Calcinator.PryIn.InstrumenterTest do
         end
       )
     end
+
+    test "in Calcinator.show_relationship/3" do
+      meta = checkout_meta()
+      %TestPost{author: %TestAuthor{}, id: id} = Factory.insert(:test_post)
+
+      CustomTrace.start(group: "TestPost", key: "show_relationship")
+
+      {:ok, _} = Calcinator.show_relationship(
+        %Calcinator{ecto_schema_module: TestPost, resources_module: TestPosts, view_module: TestPostView},
+        %{
+          "post_id" => id,
+          "meta" => meta
+        },
+        %{
+          related: %{
+            view_module: TestAuthorView
+          },
+          source: %{
+            association: :author,
+            id_key: "post_id"
+          }
+        }
+      )
+
+      CustomTrace.finish()
+
+      assert [
+               %PryIn.Interaction{
+                 context: context,
+                 custom_group: "TestPost",
+                 custom_key: "show_relationship",
+                 custom_metrics: custom_metrics,
+                 type: :custom_trace
+               }
+             ] = InteractionStore.get_state.finished_interactions
+
+      assert is_list(context)
+      assert length(context) == 4
+
+      assert {"calcinator/can/actions/show/targets/" <>
+              "[%Calcinator.Resources.TestAuthor{}, %Calcinator.Resources.TestPost{}]/authorization_module",
+               "Calcinator.Authorization.SubjectLess"} in context
+      assert {"calcinator/can/actions/show/targets/" <>
+              "[%Calcinator.Resources.TestAuthor{}, %Calcinator.Resources.TestPost{}]/subject",
+               "nil"} in context
+      assert {"calcinator/can/actions/show/targets/%Calcinator.Resources.TestPost{}/authorization_module",
+               "Calcinator.Authorization.SubjectLess"} in context
+      assert {"calcinator/can/actions/show/targets/%Calcinator.Resources.TestPost{}/subject",
+               "nil"} in context
+
+      assert is_list(custom_metrics)
+      assert length(custom_metrics) == 2
+
+      Enum.each(
+        custom_metrics,
+        fn custom_metric ->
+          assert %PryIn.Interaction.CustomMetric{
+                   duration: duration,
+                   file: file,
+                   function: "can/3",
+                   key: "calcinator_can_show",
+                   line: line,
+                   module: Calcinator,
+                   pid: pid
+                 } = custom_metric
+          refute is_nil(duration)
+          refute is_nil(file)
+          refute is_nil(line)
+          refute is_nil(pid)
+        end
+      )
+    end
   end
 end

--- a/test/calcinator/pry_in/instrumenter_test.exs
+++ b/test/calcinator/pry_in/instrumenter_test.exs
@@ -73,22 +73,16 @@ defmodule Calcinator.PryIn.InstrumenterTest do
       assert is_list(custom_metrics)
       assert length(custom_metrics) == 2
 
+      assert_custom_metrics_filled(custom_metrics)
+
       Enum.each(
         custom_metrics,
         fn custom_metric ->
           assert %PryIn.Interaction.CustomMetric{
-                   duration: duration,
-                   file: file,
                    function: "can/3",
                    key: "calcinator_can_create",
-                   line: line,
                    module: Calcinator,
-                   pid: pid
                  } = custom_metric
-          refute is_nil(duration)
-          refute is_nil(file)
-          refute is_nil(line)
-          refute is_nil(pid)
         end
       )
     end
@@ -130,22 +124,16 @@ defmodule Calcinator.PryIn.InstrumenterTest do
       assert is_list(custom_metrics)
       assert length(custom_metrics) == 1
 
+      assert_custom_metrics_filled(custom_metrics)
+
       Enum.each(
         custom_metrics,
         fn custom_metric ->
           assert %PryIn.Interaction.CustomMetric{
-                   duration: duration,
-                   file: file,
                    function: "can/3",
                    key: "calcinator_can_delete",
-                   line: line,
                    module: Calcinator,
-                   pid: pid
                  } = custom_metric
-          refute is_nil(duration)
-          refute is_nil(file)
-          refute is_nil(line)
-          refute is_nil(pid)
         end
       )
     end
@@ -202,22 +190,16 @@ defmodule Calcinator.PryIn.InstrumenterTest do
       assert is_list(custom_metrics)
       assert length(custom_metrics) == 2
 
+      assert_custom_metrics_filled(custom_metrics)
+
       Enum.each(
         custom_metrics,
         fn custom_metric ->
           assert %PryIn.Interaction.CustomMetric{
-                   duration: duration,
-                   file: file,
                    function: "can/3",
                    key: "calcinator_can_show",
-                   line: line,
-                   module: Calcinator,
-                   pid: pid
+                   module: Calcinator
                  } = custom_metric
-          refute is_nil(duration)
-          refute is_nil(file)
-          refute is_nil(line)
-          refute is_nil(pid)
         end
       )
     end
@@ -262,22 +244,16 @@ defmodule Calcinator.PryIn.InstrumenterTest do
       assert is_list(custom_metrics)
       assert length(custom_metrics) == 1
 
+      assert_custom_metrics_filled(custom_metrics)
+
       Enum.each(
         custom_metrics,
         fn custom_metric ->
           assert %PryIn.Interaction.CustomMetric{
-                   duration: duration,
-                   file: file,
                    function: "can/3",
                    key: "calcinator_can_index",
-                   line: line,
                    module: Calcinator,
-                   pid: pid
                  } = custom_metric
-          refute is_nil(duration)
-          refute is_nil(file)
-          refute is_nil(line)
-          refute is_nil(pid)
         end
       )
     end
@@ -319,22 +295,16 @@ defmodule Calcinator.PryIn.InstrumenterTest do
       assert is_list(custom_metrics)
       assert length(custom_metrics) == 1
 
+      assert_custom_metrics_filled(custom_metrics)
+
       Enum.each(
         custom_metrics,
         fn custom_metric ->
           assert %PryIn.Interaction.CustomMetric{
-                   duration: duration,
-                   file: file,
                    function: "can/3",
                    key: "calcinator_can_show",
-                   line: line,
                    module: Calcinator,
-                   pid: pid
                  } = custom_metric
-          refute is_nil(duration)
-          refute is_nil(file)
-          refute is_nil(line)
-          refute is_nil(pid)
         end
       )
     end
@@ -391,22 +361,16 @@ defmodule Calcinator.PryIn.InstrumenterTest do
       assert is_list(custom_metrics)
       assert length(custom_metrics) == 2
 
+      assert_custom_metrics_filled(custom_metrics)
+
       Enum.each(
         custom_metrics,
         fn custom_metric ->
           assert %PryIn.Interaction.CustomMetric{
-                   duration: duration,
-                   file: file,
                    function: "can/3",
                    key: "calcinator_can_show",
-                   line: line,
-                   module: Calcinator,
-                   pid: pid
+                   module: Calcinator
                  } = custom_metric
-          refute is_nil(duration)
-          refute is_nil(file)
-          refute is_nil(line)
-          refute is_nil(pid)
         end
       )
     end
@@ -488,23 +452,38 @@ defmodule Calcinator.PryIn.InstrumenterTest do
       assert "calcinator_can_show" in custom_metric_keys
       assert "calcinator_can_update" in custom_metric_keys
 
+      assert_custom_metrics_filled(custom_metrics)
+
       Enum.each(
         custom_metrics,
         fn custom_metric ->
-          assert %PryIn.Interaction.CustomMetric{
-                   duration: duration,
-                   file: file,
-                   function: "can/3",
-                   line: line,
-                   module: Calcinator,
-                   pid: pid
-                 } = custom_metric
-          refute is_nil(duration)
-          refute is_nil(file)
-          refute is_nil(line)
-          refute is_nil(pid)
+          assert %PryIn.Interaction.CustomMetric{function: "can/3", module: Calcinator} = custom_metric
         end
       )
     end
+  end
+
+  def assert_custom_metrics_filled(custom_metrics) do
+    Enum.each(
+      custom_metrics,
+      fn custom_metric ->
+        assert %PryIn.Interaction.CustomMetric{
+                 duration: duration,
+                 file: file,
+                 function: function,
+                 key: key,
+                 line: line,
+                 module: module,
+                 pid: pid
+               } = custom_metric
+        refute is_nil(function)
+        refute is_nil(duration)
+        refute is_nil(file)
+        refute is_nil(key)
+        refute is_nil(line)
+        refute is_nil(module)
+        refute is_nil(pid)
+      end
+    )
   end
 end

--- a/test/calcinator/pry_in/instrumenter_test.exs
+++ b/test/calcinator/pry_in/instrumenter_test.exs
@@ -1,0 +1,94 @@
+defmodule Calcinator.PryIn.InstrumenterTest do
+  use Calcinator.PryIn.Case
+
+  import Calcinator.Resources.Ecto.Repo.Repo.Case
+
+  alias Calcinator.Resources.Ecto.Repo.{Factory, TestPosts}
+  alias Calcinator.Resources.{TestAuthor, TestPost}
+  alias Calcinator.TestPostView
+  alias PryIn.{CustomTrace, InteractionStore}
+
+  describe "calcinator_can/3" do
+    test "in Calcinator.create/2" do
+      meta = checkout_meta()
+
+      %TestAuthor{id: author_id} = Factory.insert(:test_author)
+      body = "First Post!"
+
+      CustomTrace.start(group: "TestPost", key: "create")
+
+      assert {:ok, _test_post_json} = Calcinator.create(
+        %Calcinator{
+          associations_by_include: %{
+            "author" => :author
+          },
+          ecto_schema_module: TestPost,
+          resources_module: TestPosts,
+          view_module: TestPostView
+        },
+        %{
+          "meta" => meta,
+          "data" => %{
+            "type" => "test-posts",
+            "attributes" => %{
+              "body" => body
+            },
+            "relationships" => %{
+              "author" => %{
+                "data" => %{
+                  "type" => "test-authors",
+                  "id" => to_string(author_id)
+                }
+              }
+            }
+          },
+          "include" => "author"
+        }
+      )
+
+      CustomTrace.finish()
+
+      assert [
+               %PryIn.Interaction{
+                 context: context,
+                 custom_group: "TestPost",
+                 custom_key: "create",
+                 custom_metrics: custom_metrics,
+                 type: :custom_trace
+               }
+             ] = InteractionStore.get_state.finished_interactions
+
+      assert is_list(context)
+      assert length(context) == 4
+
+      assert {"calcinator/can/actions/create/targets/%Ecto.Changeset{data: %Calcinator.Resources.TestPost{}}/" <>
+              "authorization_module",
+               "Calcinator.Authorization.SubjectLess"} in context
+      assert {"calcinator/can/actions/create/targets/%Ecto.Changeset{data: %Calcinator.Resources.TestPost{}}/subject",
+               "nil"} in context
+      assert {"calcinator/can/actions/create/targets/Calcinator.Resources.TestPost/authorization_module",
+               "Calcinator.Authorization.SubjectLess"} in context
+      assert {"calcinator/can/actions/create/targets/Calcinator.Resources.TestPost/subject", "nil"} in context
+
+      assert is_list(custom_metrics)
+      assert length(custom_metrics) == 2
+
+      Enum.each(custom_metrics, fn custom_metric ->
+        assert %PryIn.Interaction.CustomMetric{
+                 duration: duration,
+                 file: file,
+                 function: "can/3",
+                 key: "calcinator_can_create",
+                 line: line,
+                 module: Calcinator,
+                 pid: pid
+               } = custom_metric
+        refute is_nil(duration)
+        refute is_nil(file)
+        refute is_nil(line)
+        refute is_nil(pid)
+      end
+      )
+    end
+  end
+end

--- a/test/calcinator/pry_in/instrumenter_test.exs
+++ b/test/calcinator/pry_in/instrumenter_test.exs
@@ -430,6 +430,7 @@ defmodule Calcinator.PryIn.InstrumenterTest do
                  key: key,
                  line: line,
                  module: module,
+                 offset: offset,
                  pid: pid
                } = custom_metric
         assert is_binary(function)
@@ -438,6 +439,7 @@ defmodule Calcinator.PryIn.InstrumenterTest do
         assert is_binary(key)
         assert is_integer(line)
         assert is_binary(module)
+        assert is_integer(offset)
         assert is_binary(pid)
       end
     )

--- a/test/support/calcinator/endpoint.ex
+++ b/test/support/calcinator/endpoint.ex
@@ -1,0 +1,22 @@
+defmodule Calcinator.Endpoint do
+  @moduledoc """
+  `Phoenix.Endpoint` for `Calcinator.PryIn.InstrumenterTest`
+  """
+
+  use Phoenix.Endpoint, otp_app: :calcinator
+
+  plug Plug.RequestId
+  plug Plug.Logger
+
+  plug Plug.Parsers,
+    parsers: [:urlencoded, :multipart, :json],
+    pass: ["*/*"],
+    json_decoder: Poison,
+    length: 25_000_000 # 25 MB
+
+  plug Plug.MethodOverride
+  plug Plug.Head
+
+  plug PryIn.Plug
+  plug Calcinator.Router
+end

--- a/test/support/calcinator/pry_in/api/test.ex
+++ b/test/support/calcinator/pry_in/api/test.ex
@@ -1,0 +1,60 @@
+# Based on https://github.com/pryin-io/pryin/blob/9fec04d61a7b8d4ff337653294f13c4e345c7029/test/support/test_api.ex
+defmodule Calcinator.PryIn.Api.Test do
+  @moduledoc """
+  Test `PryIn.Api` that sends data sent by `send_data/1` and `send_system_metrics/1` back to listeners instead of of
+  `pryin.io`.
+  """
+
+  @behaviour PryIn.Api
+
+  use GenServer
+
+  # Functions
+
+  def start_link do
+    GenServer.start_link(__MODULE__, [], [name: __MODULE__])
+  end
+
+  def subscribe do
+    GenServer.call(__MODULE__, {:subscribe, self()})
+  end
+
+  ## PryIn.Api callbacks
+
+  @impl PryIn.Api
+  def send_data(interactions) do
+    GenServer.call(__MODULE__, {:send_data, interactions})
+  end
+
+  @impl PryIn.Api
+  def send_system_metrics(data) do
+    GenServer.call(__MODULE__, {:send_system_metrics, data})
+  end
+
+  ## GenServer callbacks
+
+  @impl GenServer
+  def handle_call({:subscribe, pid}, _from, listeners) do
+    {:reply, :ok, [pid | listeners]}
+  end
+
+  @impl GenServer
+  def handle_call({:send_data, data}, _from, listeners) do
+    send_to_listeners(listeners, {:data_sent, data})
+    {:reply, :ok, listeners}
+  end
+
+  @impl GenServer
+  def handle_call({:send_system_metrics, data}, _from, listeners) do
+    send_to_listeners(listeners, {:system_metrics_sent, data})
+    {:reply, :ok, listeners}
+  end
+
+  ## Private Functons
+
+  defp send_to_listeners(listeners, message) do
+    for listener <- listeners do
+      send listener, message
+    end
+  end
+end

--- a/test/support/calcinator/pry_in/case.ex
+++ b/test/support/calcinator/pry_in/case.ex
@@ -1,0 +1,34 @@
+# Based on https://github.com/pryin-io/pryin/blob/9fec04d61a7b8d4ff337653294f13c4e345c7029/test/support/pryin_case.ex
+defmodule Calcinator.PryIn.Case do
+  @moduledoc """
+  Starts `Calcinator.PryIn.Api.Test` and subscribes to it.
+  """
+
+  use ExUnit.CaseTemplate
+
+  alias Calcinator.PryIn.Api.Test
+  alias PryIn.InteractionStore
+
+  setup do
+    ensure_test_api_stopped()
+    InteractionStore.reset_state()
+    {:ok, _} = Test.start_link()
+    Test.subscribe()
+
+    :ok
+  end
+
+  defp ensure_test_api_stopped do
+    case Process.whereis(Test) do
+      nil -> :ok
+      pid ->
+        api_ref = Process.monitor(pid)
+        Process.exit(pid, :kill)
+        receive do
+          {:DOWN, ^api_ref, _, _, _} -> :ok
+        after
+          1_000 -> raise "did not receive #{inspect(Test)} down message after 1s"
+        end
+    end
+  end
+end

--- a/test/support/calcinator/resources/ecto/repo/repo/case.ex
+++ b/test/support/calcinator/resources/ecto/repo/repo/case.ex
@@ -1,0 +1,25 @@
+defmodule Calcinator.Resources.Ecto.Repo.Repo.Case do
+  @moduledoc """
+  Helpers for accessing `Calcinator.Resources.Ecto.Repo.Repo`.
+  """
+
+  alias Calcinator.Meta.Beam
+  alias Calcinator.Resources.Ecto.Repo.Repo
+
+  @doc """
+  Checks out connection to `Calcinator.Resources.Ecto.Repo.Repo` from `Ecto.Adapters.SQL.Sandbox` and return the
+  `"meta"` to pass in params to reconnect to that connection from the controller.
+  """
+  def checkout_meta do
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(Repo)
+
+    %{}
+    |> Beam.put(Repo)
+    |> Enum.into(
+         %{},
+         fn {key, value} ->
+           {to_string(key), value}
+         end
+       )
+  end
+end

--- a/test/support/calcinator/resources/test_post.ex
+++ b/test/support/calcinator/resources/test_post.ex
@@ -5,7 +5,7 @@ defmodule Calcinator.Resources.TestPost do
 
   use Ecto.Schema
 
-  import Ecto.Changeset, only: [cast: 3, validate_required: 2]
+  import Ecto.Changeset, only: [validate_required: 2]
 
   alias Calcinator.Resources.{TestAuthor, TestComment, TestTag}
 
@@ -31,12 +31,6 @@ defmodule Calcinator.Resources.TestPost do
   def changeset(changeset) do
     changeset
     |> validate_required(required_fields())
-  end
-
-  def changeset(data, params) do
-    data
-    |> cast(params, optional_fields() ++ required_fields())
-    |> changeset()
   end
 
   def optional_fields, do: []

--- a/test/support/calcinator/router.ex
+++ b/test/support/calcinator/router.ex
@@ -1,0 +1,20 @@
+defmodule Calcinator.Router do
+  @moduledoc """
+  Router configuration and mapping file.  Scopes must be "piped" through a pipeline.  Only current pipeline is :api for
+  JSON:API only requests and responses
+  """
+
+  use Phoenix.Router
+
+  pipeline :api do
+    plug :accepts, ["json-api"]
+    plug JaSerializer.ContentTypeNegotiation
+    plug JaSerializer.Deserializer
+  end
+
+  scope "/api", Calcinator do
+    pipe_through :api
+
+    resources "/test-posts", TestPostController
+  end
+end

--- a/test/support/calcinator/test_post_controller.ex
+++ b/test/support/calcinator/test_post_controller.ex
@@ -1,0 +1,20 @@
+defmodule Calcinator.TestPostController do
+  @moduledoc """
+  Test controller for `Calcinator.PryIn.InstrumenterTest`
+  """
+
+  alias Calcinator.Controller
+
+  use Phoenix.Controller
+  use Controller,
+      actions: ~w(create delete get_related_resource index show show_relationship update)a,
+      configuration: %Calcinator{
+        associations_by_include: %{
+          "author" => :author,
+          "tags" => :tags
+        },
+        ecto_schema_module: Calcinator.Resources.TestPost,
+        resources_module: Calcinator.Resources.Ecto.Repo.TestPosts,
+        view_module: Calcinator.TestPostView
+      }
+end

--- a/test/support/calcinator/test_post_view.ex
+++ b/test/support/calcinator/test_post_view.ex
@@ -33,8 +33,9 @@ defmodule Calcinator.TestPostView do
     RelationshipView.render("show_relationship.json-api", Map.put(options, :view, __MODULE__))
   end
 
-  ## JaSerializer.PhoenixView callbacks
+  ## JaSerializer.Serializer callbacks
 
+  @impl JaSerializer.Serializer
   def relationships(test_post, conn) do
     test_post
     |> super(conn)

--- a/test/support/calcinator/test_tag_view.ex
+++ b/test/support/calcinator/test_tag_view.ex
@@ -3,7 +3,7 @@ defmodule Calcinator.TestTagView do
   View for `Calcinator.TestTag`
   """
 
-  alias Calcinator.{RelatedView, RelationshipView, TestPostView}
+  alias Calcinator.TestPostView
 
   use JaSerializer.PhoenixView
   use Calcinator.JaSerializer.PhoenixView,
@@ -19,16 +19,6 @@ defmodule Calcinator.TestTagView do
 
   has_many :posts,
            serializers: TestPostView
-
-  # Functions
-
-  def render("get_related_resource.json-api", options) do
-    RelatedView.render("get_related_resource.json-api", Map.put(options, :view, __MODULE__))
-  end
-
-  def render("show_relationship.json-api", options) do
-    RelationshipView.render("show_relationship.json-api", Map.put(options, :view, __MODULE__))
-  end
 
   ## JaSerializer.PhoenixView callbacks
 


### PR DESCRIPTION
# Changelog
## Enhancements
* `Calcinator` now instruments calls to subsystem with events, similar to `Phoenix` instrumentation.

  | event                      | subsystem                  |
  |----------------------------|----------------------------|
  | `alembic`                  | `Alembic`                  |
  | `calcinator_authorization` | `Calcinator.Authorization` |
  | `calcinator_resources`     | `Calcinator.Resources`     |
  | `calcinator_view`          | `Calcinator.View`          |

  Instrumenters can be configured with

  ```elixir
  config :calcinator,
             instrumenters: [...]
  ```
  
  * [`pryin`](https://github.com/pryin-io/pryin) instrumentation can be configured following the [`pryin` installation instructions](https://github.com/pryin-io/pryin#installation) and then adding `Calcinator.PryIn.Instrumenter` to your `:calcinator` config
    
     ```elixir
     config :calcinator,
             :instrumenters: [Calcinator.PryIn.Instrumenter]

  * Custom instrumenters can be created following the docs in `Calcinator.Instrument` 

## Bug Fixes
* The `@typedoc` and `@type` for `Calcinator.t` now has all the current struct fields documented and typed.

## Incompatible Changes
* In order to facilitate passing the entire `Calcinator.t` struct to `calcinator_resources` event callbacks in instrumenters, `Calcinator. get(Calcinator.Resources.t, params, id_key :: String.t, Resources.query_options)` has changed to `Calcinator. get(Calcinator.t, params, id_key :: String.t, Resources.query_options)`: The first argument must be the entire `Calcinator.t` struct instead of the `Calcinator.Resources.t` module that was in the `Calcinator.t` `resources_module` field.