### PR TITLE
Include id of subject and targets in context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,7 +99,9 @@
 ### Bug Fixes
 * [#31](https://github.com/C-S-D/calcinator/pull/31) - The `@typedoc` and `@type` for `Calcinator.t` now has all the current struct fields documented and typed. - [@KronicDeth](https://github.com/KronicDeth)
 * [#32](https://github.com/C-S-D/calcinator/pull/32) - [@KronicDeth](https://github.com/KronicDeth)
-
+  * README formatting
+    * Consistently use `--` instead of `---` for path marker as `--` becomes em dash in Markdown to HTML conversion
+    * Add missing \`\`\` for code blocks.
 
 ### Incompatible Changes
 * [#31](https://github.com/C-S-D/calcinator/pull/31) - In order to facilitate passing the entire `Calcinator.t` struct to `calcinator_resources` event callbacks in instrumenters, `Calcinator. get(Calcinator.Resources.t, params, id_key :: String.t, Resources.query_options)` has changed to `Calcinator. get(Calcinator.t, params, id_key :: String.t, Resources.query_options)`: The first argument must be the entire `Calcinator.t` struct instead of the `Calcinator.Resources.t` module that was in the `Calcinator.t` `resources_module` field. - [@KronicDeth](https://github.com/KronicDeth)
@@ -109,9 +111,6 @@
 ### Bug Fixes
 * [#30](https://github.com/C-S-D/calcinator/pull/30) - [@KronicDeth](https://github.com/KronicDeth)
   * `Calcinator.Resources.changeset/1,2` is allowed to get `many_to_many` associations from the backing store, so during testing, this means that the sandbox access must be allowed prior to calling `changeset`.  This was already the case for other actions, but for `create`, `allow_sandbox_access` was not called until the `Ecto.Changeset.t` was authorized and about to be created.
-* README formatting
-  * Consistently use `--` instead of `---` for path marker as `--` becomes em dash in Markdown to HTML conversion
-  * Add missing ``` for code blocks.
 
 ## v4.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@
     * `faker` `0.9.0`
     * `junit_formatter` `2.0.0`
     * `uuid` `1.1.8`
+* [#33](https://github.com/C-S-D/calcinator/pull/33) - Include the `id` field subject and target structs in `Calcinator.PryIn.Instrumenter` context entries. - [@KronicDeth](https://github.com/KronicDeth)
 
 ### Bug Fixes
 * [#31](https://github.com/C-S-D/calcinator/pull/31) - The `@typedoc` and `@type` for `Calcinator.t` now has all the current struct fields documented and typed. - [@KronicDeth](https://github.com/KronicDeth)

--- a/lib/calcinator/pry_in/instrumenter.ex
+++ b/lib/calcinator/pry_in/instrumenter.ex
@@ -291,14 +291,14 @@ if Code.ensure_loaded?(PryIn) do
     end
 
     defp subject_name(nil), do: "nil"
-    defp subject_name(%subject_module{}), do: "%#{module_name(subject_module)}{}"
+    defp subject_name(%subject_module{id: id}), do: "%#{module_name(subject_module)}{id: #{inspect(id)}}"
 
     defp target_name(nil), do: "nil"
     defp target_name(target) when is_atom(target), do: module_name(target)
     defp target_name(%target_module{data: data}) when target_module == Ecto.Changeset do
       "%#{module_name(target_module)}{data: #{target_name(data)}}"
     end
-    defp target_name(%target_module{}), do: "%#{target_name(target_module)}{}"
+    defp target_name(%target_module{id: id}), do: "%#{target_name(target_module)}{id: #{inspect(id)}}"
     defp target_name(association_ascent) when is_list(association_ascent) do
       "[#{Enum.map_join(association_ascent, ", ", &target_name/1)}]"
     end


### PR DESCRIPTION
# Changelog
## Enhancements
* Include the `id` field subject and target structs in `Calcinator.PryIn.Instrumenter` context entries.