### PR TITLE
Calcinator.Resources.Ecto.Repo sorting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,9 @@
 ## v5.1.0
 
 ### Enhancements
+* [#36](https://github.com/C-S-D/calcinator/pull/36) - [@KronicDeth](https://github.com/KronicDeth)
+  * Update to latest `mix.lock` format.
+  * JaSerializer [supports](https://github.com/vt-elixir/ja_serializer#fields) [sparse fieldsets](http://jsonapi.org/format/#fetching-sparse-fieldsets), but `Calcinator.JaSerializer.PhoenixView`'s `params_to_render_opts/1` was only copying `params["include"]` to `opts[:include]`, so now copy over both `"include"` and `"fields"` if present.
 * [#37[(https://github.com/C-S-D/calcinator/pull/37) - [@KronicDeth](https://github.com/KronicDeth)
   * `Calcinator.Resource.Ecto.Repo.list/2`  supports configurable pagination through
 
@@ -83,14 +86,42 @@
      config :calcinator, Calcinator.Resources.Page, size: [default: 10, maximum: 25]
     ```
   * Update `credo` to `0.8.10` for Elixir 1.6 compatibility.
-* [#36](https://github.com/C-S-D/calcinator/pull/36) - [@KronicDeth](https://github.com/KronicDeth)
-  * Update to latest `mix.lock` format.
-  * JaSerializer [supports](https://github.com/vt-elixir/ja_serializer#fields) [sparse fieldsets](http://jsonapi.org/format/#fetching-sparse-fieldsets), but `Calcinator.JaSerializer.PhoenixView`'s `params_to_render_opts/1` was only copying `params["include"]` to `opts[:include]`, so now copy over both `"include"` and `"fields"` if present.
+* [#41](https://github.com/C-S-D/calcinator/pull/41) - [@KronicDeth](https://github.com/KronicDeth)
+  * `c:Calcinator.Resources.list/1` from `use Calcinator.Resources.Ecto.Repo` can sort any of attribute of the primary `Ecto.Schema.t` returned by `c:Calcinator.Resources.Ecto.Repo.ecto_schema_module/0`
+
+    ```elixir
+    TestPosts.list(%{sorts: [%Calcinator.Resources.Sort{direction: :ascending, field: :inserted_at}]})
+    TestPosts.list(%{sorts: [%Calcinator.Resources.Sort{direction: :descending, field: :inserted_at}]})
+    ```
+
+    or any attribute of relationships that are mapped to associations of the primary data
+
+    ```elixir
+    TestPosts.list(%{
+                     sorts: [
+                       %Calcinator.Resources.Sort{
+                         association: :author,
+                         direction: :ascending,
+                         field: :name
+                       }
+                     ]
+                   })
+    TestPosts.list(%{
+                     sorts: [
+                       %Calcinator.Resources.Sort{
+                         association: :author,
+                         direction: :descending,
+                         field: :name
+                       }
+                     ]
+                   })
+    ```
 
 ### Bug Fixes
 * [#36](https://github.com/C-S-D/calcinator/pull/36) - [@KronicDeth](https://github.com/KronicDeth)
   * Fix Elixir 1.6 GenServer warning about not defining `init/1` explicitly.
 * [#37[(https://github.com/C-S-D/calcinator/pull/37) - `query_options[:page]` is no longer ignored when passed to `use Calcinator.Resources.Ecto.Repo`'s `list/1` by default.  To restore the old behavior change the paginator to `Calcinator.Resources.Ecto.Repo.Pagination.Ignore`. - [@KronicDeth](https://github.com/KronicDeth)
+* [#41](https://github.com/C-S-D/calcinator/pull/41) - add missing `alias Calcinator.Resources.Sorts` to `Calcinator.Resources` to fix `Sorts.t` being unknown - [@KronicDeth](https://github.com/KronicDeth)
 
 ## v5.0.0
 

--- a/README.md
+++ b/README.md
@@ -204,6 +204,39 @@ Returns based on `paginator` and `query_options` `page`
 
 If you want to define your own paginator, it must implement the `Calcinator.Resources.Ecto.Repo.Pagination` behaviour.
 
+##### Sorting
+
+`c:Calcinator.Resources.list/1` from `use Calcinator.Resources.Ecto.Repo` can sort any of attribute of the primary `Ecto.Schema.t` returned by `c:Calcinator.Resources.Ecto.Repo.ecto_schema_module/0`
+
+```elixir
+TestPosts.list(%{sorts: [%Calcinator.Resources.Sort{direction: :ascending, field: :inserted_at}]})
+TestPosts.list(%{sorts: [%Calcinator.Resources.Sort{direction: :descending, field: :inserted_at}]})
+```
+
+or any attribute of relationships that are mapped to associations of the primary data
+
+
+```elixir
+TestPosts.list(%{
+                 sorts: [
+                   %Calcinator.Resources.Sort{
+                     association: :author,
+                     direction: :ascending,
+                     field: :name
+                   }
+                 ]
+               })
+TestPosts.list(%{
+                 sorts: [
+                   %Calcinator.Resources.Sort{
+                     association: :author,
+                     direction: :descending,
+                     field: :name
+                   }
+                 ]
+               })               
+```
+
 ## Installation
 
 If [available in Hex](https://hex.pm/docs/publish), the package can be installed as:

--- a/lib/calcinator/resources.ex
+++ b/lib/calcinator/resources.ex
@@ -4,7 +4,7 @@ defmodule Calcinator.Resources do
   """
 
   alias Alembic.{Document, Error, Source}
-  alias Calcinator.Resources.Page
+  alias Calcinator.Resources.{Page, Sorts}
 
   # Types
 

--- a/lib/calcinator/resources/ecto/repo/pagination/allow.ex
+++ b/lib/calcinator/resources/ecto/repo/pagination/allow.ex
@@ -116,6 +116,9 @@ defmodule Calcinator.Resources.Ecto.Repo.Pagination.Allow do
   end
 
   defp total_size(repo, query) do
-    repo.aggregate(query, :count, :id)
+    query
+    |> exclude(:group_by)
+    |> exclude(:order_by)
+    |> repo.aggregate(:count, :id)
   end
 end


### PR DESCRIPTION
# Changelog
## Enhancements
*  `c:Calcinator.Resources.list/1` from `use Calcinator.Resources.Ecto.Repo` can sort any of attribute of the primary `Ecto.Schema.t` returned by `c:Calcinator.Resources.Ecto.Repo.ecto_schema_module/0`

   ```elixir
   TestPosts.list(%{sorts: [%Calcinator.Resources.Sort{direction: :ascending, field: :inserted_at}]})
   TestPosts.list(%{sorts: [%Calcinator.Resources.Sort{direction: :descending, field: :inserted_at}]})
   ```

   or any attribute of relationships that are mapped to associations of the primary data

   ```elixir
   TestPosts.list(%{
                    sorts: [
                      %Calcinator.Resources.Sort{
                        association: :author,
                        direction: :ascending,
                        field: :name
                      }
                    ]
                  })
   TestPosts.list(%{
                    sorts: [
                      %Calcinator.Resources.Sort{
                        association: :author,
                        direction: :descending,
                        field: :name
                      }
                    ]
                  })               
   ```