### PR TITLE
Port @jeffutter's #34 to insert/3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,8 +120,9 @@
 ### Bug Fixes
 * [#36](https://github.com/C-S-D/calcinator/pull/36) - [@KronicDeth](https://github.com/KronicDeth)
   * Fix Elixir 1.6 GenServer warning about not defining `init/1` explicitly.
-* [#37[(https://github.com/C-S-D/calcinator/pull/37) - `query_options[:page]` is no longer ignored when passed to `use Calcinator.Resources.Ecto.Repo`'s `list/1` by default.  To restore the old behavior change the paginator to `Calcinator.Resources.Ecto.Repo.Pagination.Ignore`. - [@KronicDeth](https://github.com/KronicDeth)
+* [#37](https://github.com/C-S-D/calcinator/pull/37) - `query_options[:page]` is no longer ignored when passed to `use Calcinator.Resources.Ecto.Repo`'s `list/1` by default.  To restore the old behavior change the paginator to `Calcinator.Resources.Ecto.Repo.Pagination.Ignore`. - [@KronicDeth](https://github.com/KronicDeth)
 * [#41](https://github.com/C-S-D/calcinator/pull/41) - add missing `alias Calcinator.Resources.Sorts` to `Calcinator.Resources` to fix `Sorts.t` being unknown - [@KronicDeth](https://github.com/KronicDeth)
+* [#43](https://github.com/C-S-D/calcinator/pull/43) - Port [@jeffutter](https://github.com/jeffutter) [#34](https://github.com/C-S-D/calcinator/pull/34) to `insert/3` because similar to `update/3`, `insert/3` was missing a change to expect `changeset/2` to return an `{:ok, changeset} | {:error, reason}` tuple instead of a just a `changeset`. - [@KronicDeth](https://github.com/KronicDeth)
 
 ## v5.0.0
 

--- a/lib/calcinator/resources/ecto/repo.ex
+++ b/lib/calcinator/resources/ecto/repo.ex
@@ -297,9 +297,9 @@ defmodule Calcinator.Resources.Ecto.Repo do
   end
 
   def insert(module, params, query_options) when is_map(params) and is_map(query_options) do
-    params
-    |> module.changeset()
-    |> module.insert(query_options)
+    with {:ok, changeset} <- module.changeset(params) do
+      module.insert(changeset, query_options)
+    end
   end
 
   @doc """


### PR DESCRIPTION
# Changelog
## Bug Fixes
* Port @jeffutters #34 to `insert/3` because similar to `update/3`, `insert/3` was missing a change to expect `changeset/2` to return an `{:ok, changeset} | {:error, reason}` tuple instead of a just a `changeset`.